### PR TITLE
Allow reduced token permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.3.0 (October 31, 2019)
+
+ENHANCEMENTS:
+
+* token list permission on sys/mounts is not mandatory
+
 ## v0.2.0 (October 20, 2019)
 
 ENHANCEMENTS:

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ compile: clean
 	go build -ldflags "-X main.vshVersion=$(VERSION)" -o build/${APP_NAME}_linux_amd64
 
 integration-test:
+	./test/kv1-reduced-permissions.sh
+	./test/kv1.sh
 	./test/kv1-to-kv2.sh
+	./test/kv2-reduced-permissions.sh
 	./test/kv2-to-kv1.sh
 	./test/kv2.sh
-	./test/kv1.sh
 
 clean:
 	rm ./build/* || true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Further, copying/moving secrets between both versions is supported.
 
 vsh can also act as an executor in a non-interactive way (similar to `bash -c "<cmd>"`).
 
-Integration tests are running against vault `1.2.2`.
+Integration tests are running against vault `1.2.3`.
 
 ## Supported commands
 
@@ -30,9 +30,6 @@ cat <file-path>
 Unlike unix, `cp` and `rm` always have the `-r` flag implied, i.e., every operation works recursively on the paths.
 
 ## Interactive mode
-
-**Note:** Currently, `vsh` requires `VAULT_TOKEN` to have list permissions on `sys/mounts`. 
-This is needed to query the available backends. 
 
 ```
 export VAULT_ADDR=http://localhost:8080
@@ -53,6 +50,15 @@ export VAULT_TOKEN=<token>
 ./vsh -c "rm secret/dir/to/remove/"
 ```
 
+## Misc
+
+`vsh` attempts to reliably discover all available backends. 
+Ideally, the vault token used by `vsh` has `list` permissions on `sys/mount`. 
+If this is not the case, then `vsh` does not know the available backends beforehand. 
+That means initially there won't be path auto-completion on the top level. 
+However, `vsh` will try with best effort, to reliably determine the kv version of every entered path. 
+
+
 ## Local Development
 
 Requirements:
@@ -67,8 +73,7 @@ make integration-test
 
 ## TODOs
 
-- sys/mounts/ permission needed at the moment for auto-completion --> disable auto-completion on top level if permission not given
 - `tree` command
-- currently `mv` behaves a little different from UNIX. `mv /secret/source/a /secret/target/` should yield `/secret/target/a`
+- currently `mv` and `cp` behave a little different from UNIX. `mv /secret/source/a /secret/target/` should yield `/secret/target/a`
 - caching `List()` queries to reduce IO / token usage (?)
 - more integration tests!

--- a/client/client.go
+++ b/client/client.go
@@ -59,15 +59,12 @@ func NewClient(conf *VaultConfig) (*Client, error) {
 	vault.SetToken(conf.Token)
 
 	permissions, err := vault.Sys().CapabilitiesSelf("sys/mounts")
-	if err != nil {
-		return nil, err
-	}
 
 	var mounts map[string]*api.MountOutput
 	if sliceContains(permissions, "list") || sliceContains(permissions, "root") {
 		mounts, err = vault.Sys().ListMounts()
 	} else {
-		fmt.Println("Cannot discover mount backends: Do not have list permission on sys/mounts")
+		fmt.Println("Cannot auto-discover mount backends: Token does not have list permission on sys/mounts")
 	}
 
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"github.com/fishi0x01/vsh/log"
 	"github.com/hashicorp/vault/api"
 	"strconv"
@@ -57,7 +58,18 @@ func NewClient(conf *VaultConfig) (*Client, error) {
 
 	vault.SetToken(conf.Token)
 
-	mounts, err := vault.Sys().ListMounts()
+	permissions, err := vault.Sys().CapabilitiesSelf("sys/mounts")
+	if err != nil {
+		return nil, err
+	}
+
+	var mounts map[string]*api.MountOutput
+	if sliceContains(permissions, "list") || sliceContains(permissions, "root") {
+		mounts, err = vault.Sys().ListMounts()
+	} else {
+		fmt.Println("Cannot discover mount backends: Do not have list permission on sys/mounts")
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/test/kv-sh.sh
+++ b/test/kv-sh.sh
@@ -5,7 +5,7 @@ source $(dirname ${0})/util.sh
 export APP_BIN="./build/vsh_linux_amd64"
 export VAULT_PORT=8889
 export VAULT_TOKEN="root"
-export VAULT_VERSION="1.2.2"
+export VAULT_VERSION="1.2.3"
 export VAULT_ADDR="http://localhost:${VAULT_PORT}"
 export VAULT_CONTAINER_NAME="vault"
 

--- a/test/kv1-to-kv2.sh
+++ b/test/kv1-to-kv2.sh
@@ -5,7 +5,7 @@ source $(dirname ${0})/util.sh
 export APP_BIN="./build/vsh_linux_amd64"
 export VAULT_PORT=8888
 export VAULT_TOKEN="root"
-export VAULT_VERSION="1.2.2"
+export VAULT_VERSION="1.2.3"
 export VAULT_ADDR="http://localhost:${VAULT_PORT}"
 export VAULT_CONTAINER_NAME="vault-kv1-to-kv2-test"
 export VAULT_TEST_VALUE="test"

--- a/test/kv1.sh
+++ b/test/kv1.sh
@@ -5,7 +5,7 @@ source $(dirname ${0})/util.sh
 export APP_BIN="./build/vsh_linux_amd64"
 export VAULT_PORT=8888
 export VAULT_TOKEN="root"
-export VAULT_VERSION="1.2.2"
+export VAULT_VERSION="1.2.3"
 export VAULT_ADDR="http://localhost:${VAULT_PORT}"
 export VAULT_CONTAINER_NAME="vault-kv1-test"
 export VAULT_TEST_VALUE="test"

--- a/test/kv2-reduced-permissions.sh
+++ b/test/kv2-reduced-permissions.sh
@@ -7,13 +7,17 @@ export VAULT_PORT=8888
 export VAULT_TOKEN="root"
 export VAULT_VERSION="1.2.3"
 export VAULT_ADDR="http://localhost:${VAULT_PORT}"
-export VAULT_CONTAINER_NAME="vault-kv2-test"
+export VAULT_CONTAINER_NAME="vault-kv1-reduced-permissions"
 export VAULT_TEST_VALUE="test"
 
 { # Try
 
 ## Setup v2 KV
 start_vault ${VAULT_VERSION} ${VAULT_CONTAINER_NAME} ${VAULT_PORT}
+
+docker cp test/reduced-policy.hcl ${VAULT_CONTAINER_NAME}:.
+vault_exec ${VAULT_CONTAINER_NAME} "vault policy write reduced-access reduced-policy.hcl"
+vault_exec ${VAULT_CONTAINER_NAME} "vault token create -id=reduced -policy=reduced-access"
 
 vault_exec ${VAULT_CONTAINER_NAME} "vault kv put secret/source/a value=${VAULT_TEST_VALUE}"
 vault_exec ${VAULT_CONTAINER_NAME} "vault kv put secret/source/b value=${VAULT_TEST_VALUE}"
@@ -25,8 +29,9 @@ vault_exec ${VAULT_CONTAINER_NAME} "vault kv put secret/remove/x value=${VAULT_T
 vault_exec ${VAULT_CONTAINER_NAME} "vault kv put secret/remove/y/z value=${VAULT_TEST_VALUE}"
 
 ## Run App
+export VAULT_TOKEN="reduced"
 ${APP_BIN} -c "mv secret/source/x secret/target2/x"
-${APP_BIN} -c "mv secret/source/ secret/target/"
+${APP_BIN} -c "cp secret/source/ secret/target/"
 ${APP_BIN} -c "rm secret/remove"
 
 ## Verify result

--- a/test/kv2-to-kv1.sh
+++ b/test/kv2-to-kv1.sh
@@ -5,7 +5,7 @@ source $(dirname ${0})/util.sh
 export APP_BIN="./build/vsh_linux_amd64"
 export VAULT_PORT=8888
 export VAULT_TOKEN="root"
-export VAULT_VERSION="1.2.2"
+export VAULT_VERSION="1.2.3"
 export VAULT_ADDR="http://localhost:${VAULT_PORT}"
 export VAULT_CONTAINER_NAME="vault-kv2-to-kv1-test"
 export VAULT_TEST_VALUE="test"

--- a/test/reduced-policy.hcl
+++ b/test/reduced-policy.hcl
@@ -1,0 +1,3 @@
+path "secret/*" {
+  capabilities = ["create", "update", "read", "delete", "list"]
+}


### PR DESCRIPTION
- make `vsh` work with tokens without `list` permission on `sys/mounts`
- more integration tests for reduced permissions