### PR TITLE
Add list cache for tab-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## v0.4.1 (March 21, 2020)
+
+ENHANCEMENTS:
+
+* performance: cache `List()` queries ([#23](https://github.com/fishi0x01/vsh/issues/23))
+
 ## v0.4.0 (March 10, 2020)
 
 ENHANCEMENTS:
 
-* use TokenHelper mechanism (`github.com/hashicorp/vault/command/config`)
+* use TokenHelper mechanism ([#20](https://github.com/fishi0x01/vsh/issues/20))
 
 ## v0.3.1 (October 31, 2019)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ export VAULT_PATH=secret/  # VAULT_PATH is optional
 http://localhost:8080 /secret/> 
 ```
 
-**Note:** the given token is used for auto-completion, i.e., quite some `List()` queries are done with that token, even if you do not `rm` or `mv` anything.
+**Note:** the given token is used for auto-completion, i.e., `List()` queries are done with that token, even if you do not `rm` or `mv` anything.
+`vsh` caches `List()` results to reduce the amount of queries. However, after execution of each command the cache is cleared 
+in order to do accurate tab-completion.
 If your token has a limited number of uses, then consider using the non-interactive mode to avoid auto-completion queries.
 
 ## Non-interactive mode
@@ -79,5 +81,3 @@ make integration-test
 
 - `tree` command
 - currently `mv` and `cp` behave a little different from UNIX. `mv /secret/source/a /secret/target/` should yield `/secret/target/a`
-- caching `List()` queries to reduce IO / token usage (?)
-- more tests!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ That way you can do recursive operations on the paths.
 Both, vault KV v1 and v2 are supported. 
 Further, copying/moving secrets between both KV versions is supported.
 
-`vsh` can also act as an executor in a non-interactive way (similar to `bash -c "<cmd>"`).
+`vsh` also supports a non-interactive mode (similar to `bash -c "<cmd>"`), which 
+makes it easier to integrate with automation.
 
 Integration tests are running against vault `1.3.3`.
 

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -19,17 +19,17 @@ func NewCompleter(client *client.Client) *Completer {
 }
 
 func (c *Completer) getAbsoluteTopLevelSuggestions() []prompt.Suggest {
-	var suggestions = []prompt.Suggest{}
+	var suggestions []prompt.Suggest
 	for k := range c.client.KVBackends {
-		suggestions = append(suggestions, prompt.Suggest{"/" + k, ""})
+		suggestions = append(suggestions, prompt.Suggest{Text: "/" + k})
 	}
 	return suggestions
 }
 
 func (c *Completer) getRelativeTopLevelSuggestions() []prompt.Suggest {
-	var suggestions = []prompt.Suggest{}
+	var suggestions []prompt.Suggest
 	for k := range c.client.KVBackends {
-		suggestions = append(suggestions, prompt.Suggest{k, ""})
+		suggestions = append(suggestions, prompt.Suggest{Text: k})
 	}
 	return suggestions
 }
@@ -51,7 +51,7 @@ func (c *Completer) absolutePathSuggestions(arg string) (result []prompt.Suggest
 
 		options = append(options, "../")
 		for _, node := range options {
-			result = append(result, prompt.Suggest{queryPath + node, ""})
+			result = append(result, prompt.Suggest{Text: queryPath + node})
 		}
 	}
 
@@ -79,7 +79,7 @@ func (c *Completer) relativePathSuggestions(arg string) (result []prompt.Suggest
 
 		options = append(options, "../")
 		for _, node := range options {
-			result = append(result, prompt.Suggest{queryPath + node, ""})
+			result = append(result, prompt.Suggest{Text: queryPath + node})
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -45,6 +45,10 @@ func printVersion() {
 }
 
 func executor(in string) {
+	// Every command can change the vault content
+	// i.e., the cache should be cleared on command execution
+	vaultClient.ClearCache()
+
 	// Split the input separate the command and the arguments.
 	in = strings.TrimSpace(in)
 	args := strings.Split(in, " ")


### PR DESCRIPTION
Addresses https://github.com/fishi0x01/vsh/issues/23

`List()` queries are cached to reduce overall amount of queries for tab-completion. 
Cache is reset on execution of a command.