### PR TITLE
Fix Makefile for builds on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,15 @@
 APP_NAME := vsh
 PLATFORMS := linux darwin
 ARCHS := 386 amd64
-BRANCH := $(shell git branch | grep \* | cut -d ' ' -f2)
-TAG := $(shell git tag -l --points-at HEAD)
-VERSION := $(shell [ -n "$(TAG)" ] && echo -n "$(TAG)" || echo -n "$(BRANCH)-SNAPSHOT")
+VERSION := $(shell git describe --tags --always --dirty)
 
 cross-compile: clean
 	mkdir -p ./build/
 	for GOOS in $(PLATFORMS); do \
-	  for GOARCH in $(ARCHS); do \
-	  	export GOOS=$$GOOS; \
-		export GOARCH=$$GOARCH; \
-	    go build -ldflags "-X main.vshVersion=$(VERSION)" -o build/${APP_NAME}_$${GOOS}_$${GOARCH}; \
-	  done \
+		for GOARCH in $(ARCHS); do \
+			GOOS=$$GOOS GOARCH=$$GOARCH \
+				go build -ldflags "-X main.vshVersion=$(VERSION)" -o build/${APP_NAME}_$${GOOS}_$${GOARCH}; \
+		done \
 	done
 	ls build/
 


### PR DESCRIPTION
This PR changes the way snapshot versions are created, so that it works on MacOS.

Before this change, `VERSION` could contain spaces, e.g.: 

- code: `go build -ldflags "-X main.vshVersion=$(VERSION)"`
- run: `go build -ldflags "-X main.vshVersion=-n v0.5.0"`

which caused errors on compilation.

Note that with this PR, snapshot-versions are no longer named with a branch, but:
- Clean commit `v0.5.0-2-gc429af6` - 2nd commit after tag `v0.5.0` - all changes are committed
- Dirty commit `v0.5.0-2-gc429af6-dirty` (some changes are staged but not committed)
