### PR TITLE
Feature: Allow separation of command params with multiple whitespaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func printVersion() {
 
 func parseInput(line string) (args []string) {
 	// TODO: allow "" and "\"\""
-	return strings.Split(line, " ")
+	return strings.Fields(line)
 }
 
 func executor(in string) {

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e # required to fail test suite when a single test fails
-set -x
 
 VAULT_VERSIONS=("1.0.0" "1.4.2")
 KV_BACKENDS=("KV1" "KV2")

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
+set -e # required to fail test suite when a single test fails
+set -x
 
 VAULT_VERSIONS=("1.0.0" "1.4.2")
 KV_BACKENDS=("KV1" "KV2")
 
-export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export DIR
+BATS_OS="$(command -v bats)" || true # allow to fail
+BATS_DEFAULT="${DIR}/bin/core/bin/bats"
+BATS="${BATS_OS:-${BATS_DEFAULT}}"
 
 for vault_version in "${VAULT_VERSIONS[@]}"
 do
-    VAULT_VERSION=${vault_version} ${DIR}/bin/core/bin/bats ${DIR}/special-tests
+    VAULT_VERSION=${vault_version} ${BATS} "${DIR}/special-tests"
 
     for kv_backend in "${KV_BACKENDS[@]}"
     do
-        VAULT_VERSION=${vault_version} KV_BACKEND="${kv_backend}" ${DIR}/bin/core/bin/bats ${DIR}/command-tests
+        VAULT_VERSION=${vault_version} KV_BACKEND="${kv_backend}" ${BATS} "${DIR}/command-tests"
     done
 done

--- a/test/run.sh
+++ b/test/run.sh
@@ -7,9 +7,7 @@ KV_BACKENDS=("KV1" "KV2")
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export DIR
-BATS_OS="$(command -v bats)" || true # allow to fail
-BATS_DEFAULT="${DIR}/bin/core/bin/bats"
-BATS="${BATS_OS:-${BATS_DEFAULT}}"
+BATS="${DIR}/bin/core/bin/bats"
 
 for vault_version in "${VAULT_VERSIONS[@]}"
 do

--- a/test/special-tests/params.bats
+++ b/test/special-tests/params.bats
@@ -1,0 +1,21 @@
+load ../util/util
+load ../bin/plugins/bats-support/load
+load ../bin/plugins/bats-assert/load
+
+@test "vault-${VAULT_VERSION} whitespaces between parameters" {
+  #######################################
+  echo "==== case: copy with multiple whitespaces ===="
+  run ${APP_BIN} -c "cp    /KV2/src/prod/all      /KV2/dest/prod/all"
+  assert_success
+  assert_output --partial "Copied /KV2/src/prod/all to /KV2/dest/prod/all"
+
+  echo "==== case: copy with tabs ===="
+  run ${APP_BIN} -c "cp     /KV2/src/prod/all      /KV2/dest/prod/all       "
+  assert_success
+  assert_output --partial "Copied /KV2/src/prod/all to /KV2/dest/prod/all"
+
+  echo "==== case: append with multiple whitespaces ===="
+  run ${APP_BIN} -v -c "append    --rename    /KV2/src/prod/all      /KV2/dest/prod/all"
+  assert_success
+  assert_output --partial "Appended values from /KV2/src/prod/all to /KV2/dest/prod/all"
+}

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -58,5 +58,5 @@ vault_exec() {
 }
 
 get_vault_value() {
-  docker exec ${VAULT_CONTAINER_NAME} vault kv get -field="${1}" "${2}"
+    docker exec ${VAULT_CONTAINER_NAME} vault kv get -field="${1}" "${2}" || true
 }

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -10,7 +10,8 @@ export VAULT_ADDR="http://localhost:${VAULT_HOST_PORT}"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export DIR
-export APP_BIN="${DIR}/../../build/vsh_linux_amd64"
+UNAME=$(uname | tr '[:upper:]' '[:lower:]')
+export APP_BIN="${DIR}/../../build/vsh_${UNAME}_amd64"
 export NO_VALUE_FOUND="No value found at"
 
 setup() {


### PR DESCRIPTION
Also:
- Fix `shellcheck` warning in `run.sh` (split `export DIR=` into two separate lines)
- Add `bats` binary auto-discovery (no, this is not enough to make it work on MacOS
- Uses `set -e` in `run.sh` so that single failed test causes failure of entire test suite (and reports it as failure in GH action)