### PR TITLE
Enhancement: Unify behavior of `verbose`

### DIFF
--- a/cli/cat.go
+++ b/cli/cat.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fishi0x01/vsh/client"
 	"io"
+
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // CatCommand container for all 'cat' parameters
@@ -70,7 +72,7 @@ func (cmd *CatCommand) Run() {
 			}
 		}
 	} else {
-		fmt.Fprintln(cmd.stderr, cmd.client.Pwd+cmd.Path, "is not a file")
+		log.Error("%s%s is not a file", cmd.client.Pwd, cmd.Path)
 	}
 
 	return

--- a/cli/cd.go
+++ b/cli/cd.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fishi0x01/vsh/client"
 	"io"
+
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // CdCommand container for all 'cd' parameters
@@ -54,12 +56,12 @@ func (cmd *CdCommand) Run() {
 	t := cmd.client.GetType(newPwd)
 
 	if t == client.NONE {
-		fmt.Fprintln(cmd.stderr, "Not a valid directory: "+newPwd)
+		log.Error("Invalid directory: %s", newPwd)
 		return
 	}
 
 	if t == client.LEAF {
-		fmt.Fprintln(cmd.stderr, "Not a valid directory: "+newPwd+" is a file")
+		log.Error("Invalid directory: %s is a file", newPwd)
 		return
 	}
 

--- a/cli/cp.go
+++ b/cli/cp.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // CopyCommand container for all 'cp' parameters
@@ -57,7 +58,7 @@ func (cmd *CopyCommand) Run() {
 
 	t := cmd.client.GetType(newSrcPwd)
 	if t != client.NODE && t != client.LEAF {
-		fmt.Fprintln(cmd.stderr, "Not a valid source path: "+newSrcPwd)
+		log.Error("Invalid source path: %s", newSrcPwd)
 		return
 	}
 
@@ -79,7 +80,7 @@ func (cmd *CopyCommand) copySecret(source string, target string) error {
 		return err
 	}
 
-	fmt.Fprintln(cmd.stdout, "Copied "+source+" to "+target)
+	log.Info("Copied %s to %s", source, target)
 
 	return nil
 }

--- a/cli/grep.go
+++ b/cli/grep.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/fishi0x01/vsh/client"
 	"index/suffixarray"
 	"io"
 	"sort"
+
+	"github.com/fatih/color"
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // GrepCommand container for all 'grep' parameters
@@ -69,7 +71,7 @@ func (cmd *GrepCommand) Run() {
 
 	t := cmd.client.GetType(path)
 	if t != client.NODE && t != client.LEAF {
-		fmt.Fprintln(cmd.stderr, "Not a valid path: "+path)
+		log.Error("Invalid path: %s", path)
 		return
 	}
 

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fishi0x01/vsh/client"
 	"io"
 	"strings"
+
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // ListCommand container for 'ls' parameters
@@ -57,7 +59,7 @@ func (cmd *ListCommand) Run() {
 	result, err := cmd.client.List(newPwd)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error("%w", err)
 	} else {
 		fmt.Fprintln(cmd.stdout, strings.Join(result, "\n"))
 	}

--- a/cli/mv.go
+++ b/cli/mv.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fishi0x01/vsh/client"
 	"io"
+
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // MoveCommand container for all 'mv' parameters
@@ -56,7 +58,7 @@ func (cmd *MoveCommand) Run() {
 
 	t := cmd.client.GetType(newSrcPwd)
 	if t != client.NODE && t != client.LEAF {
-		fmt.Fprintln(cmd.stderr, "Not a valid source path: "+newSrcPwd)
+		log.Error("Invalid source path: %s", newSrcPwd)
 		return
 	}
 
@@ -83,7 +85,7 @@ func (cmd *MoveCommand) moveSecret(source string, target string) error {
 		return err
 	}
 
-	fmt.Fprintln(cmd.stdout, "Moved "+source+" to "+target)
+	log.Info("Moved %s to %s", source, target)
 
 	return nil
 }

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/fishi0x01/vsh/client"
 	"io"
+
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
 )
 
 // RemoveCommand container for all 'rm' parameters
@@ -62,7 +64,7 @@ func (cmd *RemoveCommand) Run() {
 			}
 		}
 	default:
-		fmt.Fprintln(cmd.stderr, "Not a valid path: "+newPwd)
+		log.Error("Invalid path: %s", newPwd)
 	}
 }
 
@@ -73,7 +75,7 @@ func (cmd *RemoveCommand) removeSecret(path string) error {
 		return err
 	}
 
-	fmt.Fprintln(cmd.stdout, "Removed "+path)
+	log.Info("Removed %s", path)
 
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -2,11 +2,11 @@ package client
 
 import (
 	"errors"
-	"fmt"
-	"github.com/fishi0x01/vsh/log"
-	"github.com/hashicorp/vault/api"
 	"strconv"
 	"strings"
+
+	"github.com/fishi0x01/vsh/log"
+	"github.com/hashicorp/vault/api"
 )
 
 // Client wrapper for Vault API client
@@ -65,7 +65,7 @@ func NewClient(conf *VaultConfig) (*Client, error) {
 	if sliceContains(permissions, "list") || sliceContains(permissions, "root") {
 		mounts, err = vault.Sys().ListMounts()
 	} else {
-		fmt.Println("Cannot auto-discover mount backends: Token does not have list permission on sys/mounts")
+		log.Debug("Cannot auto-discover mount backends: Token does not have list permission on sys/mounts")
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func executor(in string) {
 		fmt.Fprint(os.Stdout, "")
 		return
 	default:
-		fmt.Fprintln(os.Stderr, "Unknown command '"+args[0]+"'")
+		log.Error("Unknown command '%s'", args[0])
 		return
 	}
 

--- a/test/command-tests/ls.bats
+++ b/test/command-tests/ls.bats
@@ -20,7 +20,7 @@ load ../bin/plugins/bats-assert/load
 
   #######################################
   echo "==== case: list backends with reduced permissions ===="
-  run bash -v -c "VAULT_TOKEN=reduced ${APP_BIN} -c 'ls /'"
+  run bash -c "VAULT_TOKEN=reduced ${APP_BIN} -v -c 'ls /'"
   assert_success
   assert_output --partial "Cannot auto-discover mount backends"
 

--- a/test/command-tests/ls.bats
+++ b/test/command-tests/ls.bats
@@ -20,7 +20,7 @@ load ../bin/plugins/bats-assert/load
 
   #######################################
   echo "==== case: list backends with reduced permissions ===="
-  run bash -c "VAULT_TOKEN=reduced ${APP_BIN} -c 'ls /'"
+  run bash -v -c "VAULT_TOKEN=reduced ${APP_BIN} -c 'ls /'"
   assert_success
   assert_output --partial "Cannot auto-discover mount backends"
 

--- a/test/special-tests/params.bats
+++ b/test/special-tests/params.bats
@@ -5,12 +5,12 @@ load ../bin/plugins/bats-assert/load
 @test "vault-${VAULT_VERSION} whitespaces between parameters" {
   #######################################
   echo "==== case: copy with multiple whitespaces ===="
-  run ${APP_BIN} -c "cp    /KV2/src/prod/all      /KV2/dest/prod/all"
+  run ${APP_BIN} -v -c "cp    /KV2/src/prod/all      /KV2/dest/prod/all"
   assert_success
   assert_output --partial "Copied /KV2/src/prod/all to /KV2/dest/prod/all"
 
   echo "==== case: copy with tabs ===="
-  run ${APP_BIN} -c "cp     /KV2/src/prod/all      /KV2/dest/prod/all       "
+  run ${APP_BIN} -v -c "cp     /KV2/src/prod/all      /KV2/dest/prod/all       "
   assert_success
   assert_output --partial "Copied /KV2/src/prod/all to /KV2/dest/prod/all"
 


### PR DESCRIPTION
This PR changes the following:
- Use `log` package for log messages (this allows to respect `-v` flag setting)
- Keep using `fmt` package for commands output (like `ls`, `cat`)
- Improved selected error messages: `Not a valid` -> `Invalid`
- (automated change) Imports were sorted based on type

Pros:
- This makes errors more visible (they are red),
- This allows to hide unwanted output (by running command without `-v`)

Cons:
- This shows file and line on output. Example: `[INFO] append.go:194 Appended values from ...`

What do you think?