### PR TITLE
Add regexp flag to grep and support quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Core features are:
 
 - recursive operations on paths with `cp`, `mv` or `rm`
-- term search with `grep`
+- search with `grep` (substring or regular-expression)
 - transparency towards differences between KV1 and KV2, i.e., you can freely move/copy secrets between both
 - non-interactive mode for automation (`vsh -c "<cmd>"`)
 - merging keys with different strategies through `append`
@@ -48,7 +48,7 @@ cp <from-path> <to-path>
 append <from-secret> <to-secret> [flag]
 rm <dir-path or filel-path>
 ls <dir-path // optional>
-grep <search-term> <path>
+grep <search> <path> [-e|--regexp]
 cd <dir-path>
 cat <file-path>
 ```
@@ -131,8 +131,8 @@ tree=oak
 
 ### grep
 
-`grep` recursively searches the given term in key and value pairs. It does not support regex.
- If you are looking for copies or just trying to find the path to a certain term, this command might come in handy.
+`grep` recursively searches the given substring in key and value pairs. To treat the search string as a regular-expression, add `-e` or `--regexp` to the end of the command.
+ If you are looking for copies or just trying to find the path to a certain string, this command might come in handy.
 
 ## Setting the vault token
 

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -132,7 +132,7 @@ func (c *Completer) commandSuggestions(arg string) (result []prompt.Suggest) {
 		{Text: "append", Description: "append <from> <to> [-f|--force] | [-s|--skip] | [-r|--rename] | -s is default"},
 		{Text: "rm", Description: "rm <path> | -r is implied"},
 		{Text: "mv", Description: "mv <from> <to>"},
-		{Text: "grep", Description: "grep <term> <path>"},
+		{Text: "grep", Description: "grep <search> <path> [-e|--regexp]"},
 		{Text: "cat", Description: "cat <path>"},
 		{Text: "ls", Description: "ls <path>"},
 		{Text: "toggle-auto-completion", Description: "toggle path auto-completion on/off"},

--- a/main.go
+++ b/main.go
@@ -27,8 +27,47 @@ func printVersion() {
 }
 
 func parseInput(line string) (args []string) {
-	// TODO: allow "" and "\"\""
-	return strings.Fields(line)
+	quote := '0'
+	escaped := false
+	arg := ""
+
+	for _, c := range line {
+		switch {
+		case c == '\\' && !escaped: // next char will be escaped
+			escaped = true
+			continue
+		case escaped:
+			escaped = false
+			arg += string(c) // append char to current arg buffer
+			continue
+		case c == quote: // terminating quote
+			quote = '0'
+			args = append(args, arg)
+			arg = ""
+		case c == '"' || c == '\'':
+			if quote == '0' { // beginning quote
+				quote = c
+			} else if c != quote { // non-matching quote char
+				arg += string(c)
+			}
+		case c == ' ':
+			if quote == '0' {
+				if arg != "" { // unquoted space, store non-empty arg
+					args = append(args, arg)
+					arg = ""
+				}
+				continue
+			}
+			fallthrough
+		default:
+			arg += string(c) // append char to current arg buffer
+		}
+	}
+
+	if arg != "" { // store non-empty arg
+		args = append(args, arg)
+	}
+	return args
 }
 
 var completerInstance *completer.Completer

--- a/test/suites/commands/grep.bats
+++ b/test/suites/commands/grep.bats
@@ -31,6 +31,32 @@ load ../../bin/plugins/bats-assert/load
   assert_line --partial "/${KV_BACKEND}/src/tooling"
 
   #######################################
+  echo "==== case: grep value with quotes ===="
+  run ${APP_BIN} -c "grep \\\"quoted\\\" ${KV_BACKEND}/src/quoted/foo"
+  assert_line --partial "/${KV_BACKEND}/src/quoted/foo"
+
+  #######################################
+  echo "==== case: regexp pattern ===="
+  run ${APP_BIN} -c "grep app.* ${KV_BACKEND}/src -e"
+  assert_line --partial "/${KV_BACKEND}/src/dev/1"
+  assert_line --partial "/${KV_BACKEND}/src/ambivalence/1"
+
+  #######################################
+  echo "==== case: pattern with spaces ===="
+  run ${APP_BIN} -c "grep 'a spaced val' ${KV_BACKEND}/src/spaces"
+  assert_line --partial "/${KV_BACKEND}/src/spaces/foo"
+
+  #######################################
+  echo "==== case: pattern with escaped spaces ===="
+  run ${APP_BIN} -c "grep a\ spaced\ val ${KV_BACKEND}/src/spaces"
+  assert_line --partial "/${KV_BACKEND}/src/spaces/foo"
+
+  #######################################
+  echo "==== case: pattern with apostrophe ===="
+  run ${APP_BIN} -c "grep \"steve's\" ${KV_BACKEND}/src/apostrophe"
+  assert_line --partial "/${KV_BACKEND}/src/apostrophe"
+
+  #######################################
   echo "==== TODO case: grep term on directory with reduced permissions ===="
 
   #######################################

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -55,6 +55,9 @@ setup() {
         vault_exec "vault kv put ${kv_backend}/src/a/foo/bar value=2"
         vault_exec "vault kv put ${kv_backend}/src/b/foo value=1"
         vault_exec "vault kv put ${kv_backend}/src/b/foo/bar value=2"
+        vault_exec "echo -n \"a spaced value\" | vault kv put ${kv_backend}/src/spaces/foo bar=-"
+        vault_exec "vault kv put ${kv_backend}/src/apostrophe/foo bar=steve\'s"
+        vault_exec "echo -n 'a \"quoted\" value' | vault kv put ${kv_backend}/src/quoted/foo bar=-"
     done
 }
 
@@ -63,7 +66,7 @@ teardown() {
 }
 
 vault_exec() {
-    docker exec ${VAULT_CONTAINER_NAME} ${1} &> /dev/null
+    docker exec ${VAULT_CONTAINER_NAME} /bin/sh -c "$1" &> /dev/null
 }
 
 get_vault_value() {


### PR DESCRIPTION
This adds a regexp flag to the `grep` command in the spirit of the userland grep binary. In order to support regexps that may include spaces, supported needed added for quoting. my implementation is not very good, but it appears to get the job done including accounting for escaping.

I'm not very experienced in golang so apologies in advance.

```
# Standard term search
http://localhost:8888 /> grep fruit KV1/
/KV1/src/ambivalence/1> fruit = apple
/KV1/src/ambivalence/1/a> fruit = banana
/KV1/src/dev/1> fruit = apple
/KV1/src/dev/2> fruit = banana
/KV1/src/dev/3> fruit = berry

# Regex search
http://localhost:8888 /> grep fr.it KV1/ -e
/KV1/src/ambivalence/1> fruit = apple
/KV1/src/ambivalence/1/a> fruit = banana
/KV1/src/dev/1> fruit = apple
/KV1/src/dev/2> fruit = banana
/KV1/src/dev/3> fruit = berry

http://localhost:8888 /> grep [abcdef]rui[qrst] KV1/ -e
/KV1/src/ambivalence/1> fruit = apple
/KV1/src/ambivalence/1/a> fruit = banana
/KV1/src/dev/1> fruit = apple
/KV1/src/dev/2> fruit = banana
/KV1/src/dev/3> fruit = berry

http://localhost:8888 /> grep app.* KV1/ -e
/KV1/src/ambivalence/1> fruit = apple
/KV1/src/dev/1> fruit = apple

# quoted space search
http://localhost:8888 /> grep "spaced val" KV1/
/KV1/src/spaces/foo> bar = a spaced value

# escaped quoted search
http://localhost:8888 /> grep "\"quote" KV1/
/KV1/src/quoted/foo> bar = a "quoted" value
```
