### PR TITLE
allow limiting scope of grep to keys or values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cp <from-path> <to-path>
 append <from-secret> <to-secret> [flag]
 rm <dir-path or filel-path>
 ls <dir-path // optional>
-grep <search> <path> [-e|--regexp]
+grep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]
 cd <dir-path>
 cat <file-path>
 ```
@@ -131,7 +131,7 @@ tree=oak
 
 ### grep
 
-`grep` recursively searches the given substring in key and value pairs. To treat the search string as a regular-expression, add `-e` or `--regexp` to the end of the command.
+`grep` recursively searches the given substring in key and value pairs. To treat the search string as a regular-expression, add `-e` or `--regexp` to the end of the command. By default, both keys and values will be searched. If you would like to limit the search, you may add `-k` or `--keys` to the end of the command to search only a path's keys, or `-v` or `--values` to search only a path's values.
  If you are looking for copies or just trying to find the path to a certain string, this command might come in handy.
 
 ## Setting the vault token

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -132,7 +132,7 @@ func (c *Completer) commandSuggestions(arg string) (result []prompt.Suggest) {
 		{Text: "append", Description: "append <from> <to> [-f|--force] | [-s|--skip] | [-r|--rename] | -s is default"},
 		{Text: "rm", Description: "rm <path> | -r is implied"},
 		{Text: "mv", Description: "mv <from> <to>"},
-		{Text: "grep", Description: "grep <search> <path> [-e|--regexp]"},
+		{Text: "grep", Description: "grep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]"},
 		{Text: "cat", Description: "cat <path>"},
 		{Text: "ls", Description: "ls <path>"},
 		{Text: "toggle-auto-completion", Description: "toggle path auto-completion on/off"},

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func executor(in string) {
 	}
 
 	if err != nil && cmd != nil {
+		log.UserError("%v", err)
 		cmd.PrintUsage()
 	}
 

--- a/test/suites/commands/grep.bats
+++ b/test/suites/commands/grep.bats
@@ -42,6 +42,12 @@ load ../../bin/plugins/bats-assert/load
   assert_line --partial "/${KV_BACKEND}/src/ambivalence/1"
 
   #######################################
+  echo "==== case: fails on invalid regex pattern ===="
+  run ${APP_BIN} -c "grep '][' ${KV_BACKEND}/src/dev -e"
+  assert_line --partial "cannot parse regex"
+  assert_failure 1
+
+  #######################################
   echo "==== case: pattern with spaces ===="
   run ${APP_BIN} -c "grep 'a spaced val' ${KV_BACKEND}/src/spaces"
   assert_line --partial "/${KV_BACKEND}/src/spaces/foo"
@@ -55,6 +61,34 @@ load ../../bin/plugins/bats-assert/load
   echo "==== case: pattern with apostrophe ===="
   run ${APP_BIN} -c "grep \"steve's\" ${KV_BACKEND}/src/apostrophe"
   assert_line --partial "/${KV_BACKEND}/src/apostrophe"
+
+  #######################################
+  echo "==== case: no match when only searching keys ===="
+  run ${APP_BIN} -c "grep 'apple' ${KV_BACKEND}/src/dev/1 -k"
+  refute_line --partial "/${KV_BACKEND}/src/dev/1"
+
+  #######################################
+  echo "==== case: no match when only searching values ===="
+  run ${APP_BIN} -c "grep 'fruit' ${KV_BACKEND}/src/dev/1 -v"
+  refute_line --partial "/${KV_BACKEND}/src/dev/1"
+
+  #######################################
+  echo "==== case: match when only searching keys ===="
+  run ${APP_BIN} -c "grep 'fruit' ${KV_BACKEND}/src/dev -k"
+  assert_line --partial "/${KV_BACKEND}/src/dev/1"
+  assert_line --partial "/${KV_BACKEND}/src/dev/2"
+  assert_line --partial "/${KV_BACKEND}/src/dev/3"
+
+  #######################################
+  echo "==== case: match when only searching values ===="
+  run ${APP_BIN} -c "grep 'apple' ${KV_BACKEND}/src/dev -v"
+  assert_line --partial "/${KV_BACKEND}/src/dev/1"
+
+  #######################################
+  echo "==== case: fails on invalid flag ===="
+  run ${APP_BIN} -c "grep 'apple' ${KV_BACKEND}/src/dev --foo"
+  assert_line --partial "invalid flag"
+  assert_failure 1
 
   #######################################
   echo "==== TODO case: grep term on directory with reduced permissions ===="


### PR DESCRIPTION
Previously, keys and values are both searched with no option to limit scope to one or the other. This pull adds two flags to grep, one for keys (`-k`/`--keys`) and one for values (`-v`/`--values`). If either of these are specified, only that part will be searched. Default behavior is preserved to search both keys and values with neither of these flags present.

This pull also makes a small change to surface errors returned by Commands as UserErrors. Previously, these errors were not able to be seen and only a usage was printed. As commands become more complex, this will help direct users to the problem.
