### PR TITLE
refactor search and implement replace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Core features are:
 
 - recursive operations on paths with `cp`, `mv` or `rm`
 - search with `grep` (substring or regular-expression)
+- substitute patterns in keys and/or values (substring or regular-expression) with `replace`
 - transparency towards differences between KV1 and KV2, i.e., you can freely move/copy secrets between both
 - non-interactive mode for automation (`vsh -c "<cmd>"`)
 - merging keys with different strategies through `append`
@@ -37,17 +38,18 @@ Download latest static binaries from [release page](https://github.com/fishi0x01
 ## Supported commands
 
 ```text
-mv <from-path> <to-path>
-cp <from-path> <to-path>
 append <from-secret> <to-secret> [flag]
-rm <dir-path or filel-path>
-ls <dir-path // optional>
-grep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]
-cd <dir-path>
 cat <file-path>
+cd <dir-path>
+cp <from-path> <to-path>
+grep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]
+ls <dir-path // optional>
+mv <from-path> <to-path>
+replace <search> <replacement> <path> [-e|--regexp] [-k|--keys] [-v|--values] [-y|--confirm] [-n|--dry-run]
+rm <dir-path or file-path>
 ```
 
-`cp`, `rm` and `grep` command always have the `-r/-R` flag implied, i.e., every operation works recursively.
+`cp`, `grep`, `replace` and `rm` command always have the `-r/-R` flag implied, i.e., every operation works recursively.
 
 ### append
 
@@ -127,6 +129,10 @@ tree=oak
 
 `grep` recursively searches the given substring in key and value pairs. To treat the search string as a regular-expression, add `-e` or `--regexp` to the end of the command. By default, both keys and values will be searched. If you would like to limit the search, you may add `-k` or `--keys` to the end of the command to search only a path's keys, or `-v` or `--values` to search only a path's values.
  If you are looking for copies or just trying to find the path to a certain string, this command might come in handy.
+
+### replace
+
+`replace` works similarly to `grep` above, but has the ability to mutate data inside Vault. By default, confirmation is required before writing data. You may skip confirmation by using the `-y`/`--confirm` flags. Conversely, you may use the `-n`/`--dry-run` flags to skip both confirmation and any writes. Changes that would be made are presented in red (delete) and green (add) coloring.
 
 ## Setting the vault token
 

--- a/cli/command.go
+++ b/cli/command.go
@@ -19,27 +19,29 @@ type Command interface {
 
 // Commands contains all available commands
 type Commands struct {
-	Mv     *MoveCommand
-	Cp     *CopyCommand
-	Append *AppendCommand
-	Rm     *RemoveCommand
-	Ls     *ListCommand
-	Cd     *CdCommand
-	Cat    *CatCommand
-	Grep   *GrepCommand
+	Mv      *MoveCommand
+	Cp      *CopyCommand
+	Append  *AppendCommand
+	Rm      *RemoveCommand
+	Ls      *ListCommand
+	Cd      *CdCommand
+	Cat     *CatCommand
+	Grep    *GrepCommand
+	Replace *ReplaceCommand
 }
 
 // NewCommands returns a Commands struct with all available commands
 func NewCommands(client *client.Client) *Commands {
 	return &Commands{
-		Mv:     NewMoveCommand(client),
-		Cp:     NewCopyCommand(client),
-		Append: NewAppendCommand(client),
-		Rm:     NewRemoveCommand(client),
-		Ls:     NewListCommand(client),
-		Cd:     NewCdCommand(client),
-		Cat:    NewCatCommand(client),
-		Grep:   NewGrepCommand(client, os.Stdout, os.Stderr),
+		Mv:      NewMoveCommand(client),
+		Cp:      NewCopyCommand(client),
+		Append:  NewAppendCommand(client),
+		Rm:      NewRemoveCommand(client),
+		Ls:      NewListCommand(client),
+		Cd:      NewCdCommand(client),
+		Cat:     NewCatCommand(client),
+		Grep:    NewGrepCommand(client, os.Stdout, os.Stderr),
+		Replace: NewReplaceCommand(client),
 	}
 }
 

--- a/cli/command.go
+++ b/cli/command.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -40,7 +39,7 @@ func NewCommands(client *client.Client) *Commands {
 		Ls:      NewListCommand(client),
 		Cd:      NewCdCommand(client),
 		Cat:     NewCatCommand(client),
-		Grep:    NewGrepCommand(client, os.Stdout, os.Stderr),
+		Grep:    NewGrepCommand(client),
 		Replace: NewReplaceCommand(client),
 	}
 }

--- a/cli/grep.go
+++ b/cli/grep.go
@@ -2,11 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 
-	"github.com/fatih/color"
 	"github.com/fishi0x01/vsh/client"
 	"github.com/fishi0x01/vsh/log"
 )
@@ -56,7 +53,7 @@ func (cmd *GrepCommand) Parse(args []string) error {
 	for _, v := range flags {
 		switch v {
 		case "-e", "--regexp":
-			cmd.doRegexp = true
+			cmd.IsRegexp = true
 		case "-k", "--keys":
 			cmd.Mode |= ModeKeys
 		case "-v", "--values":
@@ -77,20 +74,12 @@ func (cmd *GrepCommand) Parse(args []string) error {
 	return nil
 }
 
-// Run executes 'grep' with given RemoveCommand's parameters
+// Run executes 'grep' with given GrepCommand's parameters
 func (cmd *GrepCommand) Run() int {
 	path := cmdPath(cmd.client.Pwd, cmd.Path)
-	var filePaths []string
-
-	switch t := cmd.client.GetType(path); t {
-	case client.LEAF:
-		filePaths = append(filePaths, filepath.Clean(path))
-	case client.NODE:
-		for _, traversedPath := range cmd.client.Traverse(path) {
-			filePaths = append(filePaths, traversedPath)
-		}
-	default:
-		log.UserError("Not a valid path for operation: %s", path)
+	filePaths, err := cmd.client.SubpathsForPath(path)
+	if err != nil {
+		log.UserError(fmt.Sprintf("%s", err))
 		return 1
 	}
 
@@ -100,17 +89,18 @@ func (cmd *GrepCommand) Run() int {
 			return 1
 		}
 		for _, match := range matches {
-			match.print(os.Stdout)
+			match.print(os.Stdout, false)
 		}
 	}
 	return 0
 }
 
+// GetSearchParams returns the search parameters the command was run with
 func (cmd *GrepCommand) GetSearchParams() SearchParameters {
 	return SearchParameters{
-		Search: cmd.Search,
-		Mode: cmd.Mode,
-		doRegexp: cmd.doRegexp,
+		Search:   cmd.Search,
+		Mode:     cmd.Mode,
+		IsRegexp: cmd.IsRegexp,
 	}
 }
 
@@ -124,35 +114,9 @@ func (cmd *GrepCommand) grepFile(search string, path string) (matches []*Match, 
 		}
 
 		for k, v := range secret.GetData() {
-			matches = append(matches, cmd.searcher.DoMatch(path, k, fmt.Sprintf("%v", v))...)
+			matches = append(matches, cmd.searcher.DoSearch(path, k, fmt.Sprintf("%v", v))...)
 		}
 	}
 
 	return matches, nil
-}
-
-func (match *Match) print(out io.Writer) {
-	fmt.Fprint(out, match.path, "> ")
-	highlightMatches(match.key, match.keyIndex, out)
-	fmt.Fprintf(out, " = ")
-	highlightMatches(match.value, match.valueIndex, out)
-	fmt.Fprintf(out, "\n")
-}
-
-func highlightMatches(s string, index [][]int, out io.Writer) {
-	matchColor := color.New(color.FgYellow).SprintFunc()
-	cur := 0
-	if len(index) > 0 {
-		for _, pair := range index {
-			next := pair[0]
-			length := pair[1]
-			end := next + length
-			fmt.Fprint(out, s[cur:next])
-			fmt.Fprint(out, matchColor(s[next:end]))
-			cur = end
-		}
-		fmt.Fprint(out, s[cur:])
-	} else {
-		fmt.Fprint(out, s)
-	}
 }

--- a/cli/grep.go
+++ b/cli/grep.go
@@ -2,58 +2,30 @@ package cli
 
 import (
 	"fmt"
-	"index/suffixarray"
 	"io"
+	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 
 	"github.com/fatih/color"
 	"github.com/fishi0x01/vsh/client"
 	"github.com/fishi0x01/vsh/log"
 )
 
-// GrepMode defines the scope of which parts of a path to search (keys and/or values)
-type GrepMode int
-
-const (
-	// ModeKeys only searches keys
-	ModeKeys GrepMode = 1
-	// ModeValues only searches values
-	ModeValues GrepMode = 2
-)
-
 // GrepCommand container for all 'grep' parameters
 type GrepCommand struct {
 	name string
 
-	client *client.Client
-	stderr io.Writer
-	stdout io.Writer
-	Path   string
-	Search string
-	Regexp *regexp.Regexp
-	Mode   GrepMode
-}
-
-// Match structure to keep indices of matched terms
-type Match struct {
-	path  string
-	term  string
-	key   string
-	value string
-	// sorted slices of indices of match starts and length
-	keyIndex   [][]int
-	valueIndex [][]int
+	client   *client.Client
+	Path     string
+	searcher *Searcher
+	SearchParameters
 }
 
 // NewGrepCommand creates a new GrepCommand parameter container
-func NewGrepCommand(c *client.Client, stdout io.Writer, stderr io.Writer) *GrepCommand {
+func NewGrepCommand(c *client.Client) *GrepCommand {
 	return &GrepCommand{
 		name:   "grep",
 		client: c,
-		stdout: stdout,
-		stderr: stderr,
 	}
 }
 
@@ -72,11 +44,6 @@ func (cmd *GrepCommand) PrintUsage() {
 	log.UserInfo("Usage:\ngrep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]")
 }
 
-// IsMode returns true if the specified mode is enabled
-func (cmd *GrepCommand) IsMode(mode GrepMode) bool {
-	return cmd.Mode&mode == mode
-}
-
 // Parse given arguments and return status
 func (cmd *GrepCommand) Parse(args []string) error {
 	if len(args) < 3 {
@@ -89,11 +56,7 @@ func (cmd *GrepCommand) Parse(args []string) error {
 	for _, v := range flags {
 		switch v {
 		case "-e", "--regexp":
-			re, err := regexp.Compile(cmd.Search)
-			if err != nil {
-				return fmt.Errorf("cannot parse regex pattern")
-			}
-			cmd.Regexp = re
+			cmd.doRegexp = true
 		case "-k", "--keys":
 			cmd.Mode |= ModeKeys
 		case "-v", "--values":
@@ -105,6 +68,11 @@ func (cmd *GrepCommand) Parse(args []string) error {
 	if cmd.Mode == 0 {
 		cmd.Mode = ModeKeys + ModeValues
 	}
+	searcher, err := NewSearcher(cmd)
+	if err != nil {
+		return err
+	}
+	cmd.searcher = searcher
 
 	return nil
 }
@@ -132,10 +100,18 @@ func (cmd *GrepCommand) Run() int {
 			return 1
 		}
 		for _, match := range matches {
-			match.print(cmd.stdout)
+			match.print(os.Stdout)
 		}
 	}
 	return 0
+}
+
+func (cmd *GrepCommand) GetSearchParams() SearchParameters {
+	return SearchParameters{
+		Search: cmd.Search,
+		Mode: cmd.Mode,
+		doRegexp: cmd.doRegexp,
+	}
 }
 
 func (cmd *GrepCommand) grepFile(search string, path string) (matches []*Match, err error) {
@@ -148,81 +124,11 @@ func (cmd *GrepCommand) grepFile(search string, path string) (matches []*Match, 
 		}
 
 		for k, v := range secret.GetData() {
-			matches = append(matches, cmd.doMatch(path, k, fmt.Sprintf("%v", v), search)...)
+			matches = append(matches, cmd.searcher.DoMatch(path, k, fmt.Sprintf("%v", v))...)
 		}
 	}
 
 	return matches, nil
-}
-
-func (cmd *GrepCommand) doMatch(path string, k string, v string, search string) (m []*Match) {
-	if cmd.Regexp != nil {
-		return cmd.regexpMatch(path, k, v, cmd.Regexp)
-	}
-	return cmd.substrMatch(path, k, v, search)
-}
-
-// find all indices for matches in key and value
-func (cmd *GrepCommand) substrMatch(path string, k string, v string, substr string) (m []*Match) {
-	substrLength := len(substr)
-	keyMatchPairs := make([][]int, 0)
-	if cmd.IsMode(ModeKeys) {
-		keyIndex := suffixarray.New([]byte(k))
-		keyMatches := keyIndex.Lookup([]byte(substr), -1)
-		sort.Ints(keyMatches)
-		for _, offset := range keyMatches {
-			keyMatchPairs = append(keyMatchPairs, []int{offset, substrLength})
-		}
-	}
-
-	valueMatchPairs := make([][]int, 0)
-	if cmd.IsMode(ModeValues) {
-		valueIndex := suffixarray.New([]byte(v))
-		valueMatches := valueIndex.Lookup([]byte(substr), -1)
-		sort.Ints(valueMatches)
-		for _, offset := range valueMatches {
-			valueMatchPairs = append(valueMatchPairs, []int{offset, substrLength})
-		}
-	}
-
-	if len(keyMatchPairs) > 0 || len(valueMatchPairs) > 0 {
-		m = []*Match{
-			{
-				path:       path,
-				term:       substr,
-				key:        k,
-				value:      v,
-				keyIndex:   keyMatchPairs,
-				valueIndex: valueMatchPairs,
-			},
-		}
-	}
-	return m
-}
-
-func (cmd *GrepCommand) regexpMatch(path string, k string, v string, pattern *regexp.Regexp) (m []*Match) {
-	keyMatches := make([][]int, 0)
-	if cmd.IsMode(ModeKeys) {
-		keyMatches = pattern.FindAllIndex([]byte(k), -1)
-	}
-	valueMatches := make([][]int, 0)
-	if cmd.IsMode(ModeValues) {
-		valueMatches = pattern.FindAllIndex([]byte(v), -1)
-	}
-
-	if len(keyMatches) > 0 || len(valueMatches) > 0 {
-		m = []*Match{
-			{
-				path:       path,
-				term:       pattern.String(),
-				key:        k,
-				value:      v,
-				keyIndex:   keyMatches,
-				valueIndex: valueMatches,
-			},
-		}
-	}
-	return m
 }
 
 func (match *Match) print(out io.Writer) {

--- a/cli/kv_mode.go
+++ b/cli/kv_mode.go
@@ -1,6 +1,6 @@
 package cli
 
-// GrepMode defines the scope of which parts of a path to search (keys and/or values)
+// KeyValueMode defines the scope of which parts of a path to search (keys and/or values)
 type KeyValueMode int
 
 const (

--- a/cli/kv_mode.go
+++ b/cli/kv_mode.go
@@ -1,0 +1,16 @@
+package cli
+
+// GrepMode defines the scope of which parts of a path to search (keys and/or values)
+type KeyValueMode int
+
+const (
+	// ModeKeys only searches keys
+	ModeKeys KeyValueMode = 1
+	// ModeValues only searches values
+	ModeValues KeyValueMode = 2
+)
+
+// KeyValueCommand interface to describe a command that supports Key and/or Value scoping
+type KeyValueCommand interface {
+	IsMode(mode KeyValueMode) bool
+}

--- a/cli/replace.go
+++ b/cli/replace.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"github.com/fishi0x01/vsh/client"
+	"github.com/fishi0x01/vsh/log"
+)
+
+// ReplaceMode defines replacement behaviour
+type ReplaceMode string
+
+const (
+	// ModeValue only replace values
+	ModeValue ReplaceMode = "value"
+	// ModeKey only replace keys
+	ModeKey ReplaceMode = "key"
+	// ModeAll replace keys and values
+	ModeAll AppendMode = "all"
+)
+
+// ReplaceCommand container for all 'replace' parameters
+type ReplaceCommand struct {
+	name string
+
+	client   *client.Client
+	Original string
+	Replace  string
+	Target   string
+	Mode     ReplaceMode
+}
+
+// NewReplaceCommand creates a new ReplaceCommand parameter container
+func NewReplaceCommand(c *client.Client) *ReplaceCommand {
+	return &ReplaceCommand{
+		name:   "replace",
+		client: c,
+		Mode:   ModeValue,
+	}
+}
+
+// GetName returns the ReplaceCommand's name identifier
+func (cmd *ReplaceCommand) GetName() string {
+	return cmd.name
+}
+
+// IsSane returns true if command is sane
+func (cmd *ReplaceCommand) IsSane() bool {
+	return cmd.Original != "" && cmd.Target != ""
+}
+
+// PrintUsage print command usage
+func (cmd *ReplaceCommand) PrintUsage() {
+	log.UserInfo("Usage:\nreplace [--value|--key] <original> <replace> <file>")
+}
+
+// Parse parses the arguments and returns true on success; otherwise it prints usage and returns false
+func (cmd *ReplaceCommand) Parse(args []string) error {
+	// TODO
+	return nil
+}
+
+// Run executes 'replace' with given ReplaceCommand's parameters
+func (cmd *ReplaceCommand) Run() int {
+	// TODO
+	return 0
+}

--- a/cli/replace.go
+++ b/cli/replace.go
@@ -1,20 +1,12 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/cnlubo/promptx"
 	"github.com/fishi0x01/vsh/client"
 	"github.com/fishi0x01/vsh/log"
-)
-
-// ReplaceMode defines replacement behaviour
-type ReplaceMode string
-
-const (
-	// ModeValue only replace values
-	ModeValue ReplaceMode = "value"
-	// ModeKey only replace keys
-	ModeKey ReplaceMode = "key"
-	// ModeAll replace keys and values
-	ModeAll AppendMode = "all"
 )
 
 // ReplaceCommand container for all 'replace' parameters
@@ -22,10 +14,11 @@ type ReplaceCommand struct {
 	name string
 
 	client   *client.Client
-	Original string
-	Replace  string
-	Target   string
-	Mode     ReplaceMode
+	Confirm  bool
+	DryRun   bool
+	Path     string
+	searcher *Searcher
+	SearchParameters
 }
 
 // NewReplaceCommand creates a new ReplaceCommand parameter container
@@ -33,7 +26,6 @@ func NewReplaceCommand(c *client.Client) *ReplaceCommand {
 	return &ReplaceCommand{
 		name:   "replace",
 		client: c,
-		Mode:   ModeValue,
 	}
 }
 
@@ -44,22 +36,167 @@ func (cmd *ReplaceCommand) GetName() string {
 
 // IsSane returns true if command is sane
 func (cmd *ReplaceCommand) IsSane() bool {
-	return cmd.Original != "" && cmd.Target != ""
+	return cmd.Search != "" && cmd.Replacement != nil && cmd.Path != ""
 }
 
 // PrintUsage print command usage
 func (cmd *ReplaceCommand) PrintUsage() {
-	log.UserInfo("Usage:\nreplace [--value|--key] <original> <replace> <file>")
+	log.UserInfo("Usage:\nreplace <search> <replacement> <path> [-e|--regexp] [-k|--keys] [-v|--values]")
 }
 
-// Parse parses the arguments and returns true on success; otherwise it prints usage and returns false
+// GetSearchParams returns the search parameters the command was run with
+func (cmd *ReplaceCommand) GetSearchParams() SearchParameters {
+	return SearchParameters{
+		Search:      cmd.Search,
+		Replacement: cmd.Replacement,
+		Mode:        cmd.Mode,
+		IsRegexp:    cmd.IsRegexp,
+	}
+}
+
+// Parse given arguments and return status
 func (cmd *ReplaceCommand) Parse(args []string) error {
-	// TODO
+	if len(args) < 4 {
+		return fmt.Errorf("cannot parse arguments")
+	}
+	cmd.Search = args[1]
+	cmd.Replacement = &args[2]
+	cmd.Path = args[3]
+	flags := args[4:]
+
+	for _, v := range flags {
+		switch v {
+		case "-e", "--regexp":
+			cmd.IsRegexp = true
+		case "-k", "--keys":
+			cmd.Mode |= ModeKeys
+		case "-v", "--values":
+			cmd.Mode |= ModeValues
+		case "-n", "--dry-run":
+			cmd.DryRun = true
+		case "-y", "--confirm":
+			cmd.Confirm = true
+		default:
+			return fmt.Errorf("invalid flag: %s", v)
+		}
+	}
+	if cmd.Mode == 0 {
+		cmd.Mode = ModeKeys + ModeValues
+	}
+	if cmd.DryRun == true && cmd.Confirm == true {
+		cmd.Confirm = false
+	}
+	searcher, err := NewSearcher(cmd)
+	if err != nil {
+		return err
+	}
+	cmd.searcher = searcher
+
 	return nil
 }
 
 // Run executes 'replace' with given ReplaceCommand's parameters
 func (cmd *ReplaceCommand) Run() int {
-	// TODO
+	path := cmdPath(cmd.client.Pwd, cmd.Path)
+	filePaths, err := cmd.client.SubpathsForPath(path)
+	if err != nil {
+		log.UserError(fmt.Sprintf("%s", err))
+		return 1
+	}
+
+	allMatches, err := cmd.findMatches(filePaths)
+	if err != nil {
+		log.UserError(fmt.Sprintf("%s", err))
+		return 1
+	}
+	return cmd.commitMatches(allMatches)
+}
+
+func (cmd *ReplaceCommand) findMatches(filePaths []string) (matchesByPath map[string][]*Match, err error) {
+	matchesByPath = make(map[string][]*Match, 0)
+	for _, curPath := range filePaths {
+		matches, err := cmd.FindReplacements(cmd.Search, *cmd.Replacement, curPath)
+		if err != nil {
+			return matchesByPath, err
+		}
+		for _, match := range matches {
+			match.print(os.Stdout, true)
+		}
+		if len(matches) > 0 {
+			_, ok := matchesByPath[curPath]
+			if ok == false {
+				matchesByPath[curPath] = make([]*Match, 0)
+			}
+			matchesByPath[curPath] = append(matchesByPath[curPath], matches...)
+		}
+	}
+	return matchesByPath, nil
+}
+
+func (cmd *ReplaceCommand) commitMatches(matchesByPath map[string][]*Match) int {
+	if len(matchesByPath) > 0 {
+		if cmd.Confirm == false && cmd.DryRun == false {
+			p := promptx.NewDefaultConfirm("Write changes to Vault?", false)
+			result, err := p.Run()
+			if err != nil {
+				return 1
+			}
+			cmd.Confirm = result
+		}
+		if cmd.Confirm == false {
+			fmt.Println("Skipping write.")
+			return 0
+		}
+		fmt.Println("Writing!")
+		cmd.WriteReplacements(matchesByPath)
+	} else {
+		fmt.Println("No matches found to replace.")
+	}
 	return 0
+}
+
+// FindReplacements will find the matches for a given search string to be replaced
+func (cmd *ReplaceCommand) FindReplacements(search string, replacement string, path string) (matches []*Match, err error) {
+	if cmd.client.GetType(path) == client.LEAF {
+		secret, err := cmd.client.Read(path)
+		if err != nil {
+			return matches, err
+		}
+
+		for k, v := range secret.GetData() {
+			match := cmd.searcher.DoSearch(path, k, fmt.Sprintf("%v", v))
+			matches = append(matches, match...)
+		}
+	}
+	return matches, nil
+}
+
+// WriteReplacements will write replacement data back to Vault
+func (cmd *ReplaceCommand) WriteReplacements(groupedMatches map[string][]*Match) error {
+	// process matches by vault path
+	for path, matches := range groupedMatches {
+		secret, err := cmd.client.Read(path)
+		if err != nil {
+			return err
+		}
+		data := secret.GetData()
+
+		// update secret with changes. remove key w/ prior names, add renamed keys, update values.
+		for _, match := range matches {
+			if path != match.path {
+				return fmt.Errorf("match path does not equal group path")
+			}
+			if match.replacedKey != match.key {
+				delete(data, match.key)
+			}
+			data[match.replacedKey] = match.replacedValue
+		}
+		secret.SetData(data)
+
+		err = cmd.client.Write(path, secret)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cli/search.go
+++ b/cli/search.go
@@ -3,33 +3,46 @@ package cli
 import (
 	"fmt"
 	"index/suffixarray"
+	"io"
 	"regexp"
 	"sort"
+	"strings"
+
+	"github.com/andreyvit/diff"
+	"github.com/fatih/color"
 )
 
 // SearchingCommand interface to describe a command that performs a search operation
 type SearchingCommand interface {
-  GetSearchParams() SearchParameters
+	GetSearchParams() SearchParameters
 }
 
+// SearchParameters struct are parameters common to a command that performs a search operation
 type SearchParameters struct {
 	Search      string
-	Replacement string
+	Replacement *string
 	Mode        KeyValueMode
-  doRegexp bool
+	IsRegexp    bool
 }
 
-// Match structure to keep indices of matched terms
+// Match structure to keep indices of matched and replaced terms
 type Match struct {
 	path  string
-	term  string
 	key   string
 	value string
 	// sorted slices of indices of match starts and length
 	keyIndex   [][]int
 	valueIndex [][]int
+	// in-line diffs of key and value replacements
+	keyLineDiff   string
+	valueLineDiff string
+	// final strings after replacement
+	replacedKey   string
+	replacedValue string
 }
 
+// Searcher provides matching and replacement methods while maintaining references to the command
+// that provides an interface to search operations. Also maintains reference to a compiled regexp.
 type Searcher struct {
 	cmd    SearchingCommand
 	regexp *regexp.Regexp
@@ -41,7 +54,7 @@ func NewSearcher(cmd SearchingCommand) (*Searcher, error) {
 	var err error
 	params := cmd.GetSearchParams()
 
-	if params.doRegexp {
+	if params.IsRegexp {
 		re, err = regexp.Compile(params.Search)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse regex pattern")
@@ -56,72 +69,117 @@ func (s *Searcher) IsMode(mode KeyValueMode) bool {
 	return s.cmd.GetSearchParams().Mode&mode == mode
 }
 
-func (s *Searcher) DoMatch(path string, k string, v string) (m []*Match) {
-	if s.regexp != nil {
-		return s.regexpMatch(path, k, v)
-	}
-	return s.substrMatch(path, k, v)
-}
+// DoSearch searches with either regexp or substring search methods
+func (s *Searcher) DoSearch(path string, k string, v string) (m []*Match) {
+	// Default to original strings
+	replacedKey, keyLineDiff := k, k
+	replacedValue, valueLineDiff := v, v
+	var keyMatchPairs, valueMatchPairs [][]int
 
-// find all indices for matches in key and value
-func (s *Searcher) substrMatch(path string, k string, v string) (m []*Match) {
-	substrLength := len(s.cmd.GetSearchParams().Search)
-	keyMatchPairs := make([][]int, 0)
 	if s.IsMode(ModeKeys) {
-		keyIndex := suffixarray.New([]byte(k))
-		keyMatches := keyIndex.Lookup([]byte(s.cmd.GetSearchParams().Search), -1)
-		sort.Ints(keyMatches)
-		for _, offset := range keyMatches {
-			keyMatchPairs = append(keyMatchPairs, []int{offset, substrLength})
-		}
+		keyMatchPairs, replacedKey, keyLineDiff = s.matchData(k, s.cmd.GetSearchParams().IsRegexp)
 	}
 
-	valueMatchPairs := make([][]int, 0)
 	if s.IsMode(ModeValues) {
-		valueIndex := suffixarray.New([]byte(v))
-		valueMatches := valueIndex.Lookup([]byte(s.cmd.GetSearchParams().Search), -1)
-		sort.Ints(valueMatches)
-		for _, offset := range valueMatches {
-			valueMatchPairs = append(valueMatchPairs, []int{offset, substrLength})
-		}
+		valueMatchPairs, replacedValue, valueLineDiff = s.matchData(v, s.cmd.GetSearchParams().IsRegexp)
 	}
 
 	if len(keyMatchPairs) > 0 || len(valueMatchPairs) > 0 {
 		m = []*Match{
 			{
-				path:       path,
-				term:       s.cmd.GetSearchParams().Search,
-				key:        k,
-				value:      v,
-				keyIndex:   keyMatchPairs,
-				valueIndex: valueMatchPairs,
+				path:          path,
+				key:           k,
+				value:         v,
+				keyIndex:      keyMatchPairs,
+				valueIndex:    valueMatchPairs,
+				keyLineDiff:   keyLineDiff,
+				valueLineDiff: valueLineDiff,
+				replacedKey:   replacedKey,
+				replacedValue: replacedValue,
 			},
 		}
 	}
 	return m
 }
 
-func (s *Searcher) regexpMatch(path string, k string, v string) (m []*Match) {
-	keyMatches := make([][]int, 0)
-	if s.IsMode(ModeKeys) {
-		keyMatches = s.regexp.FindAllIndex([]byte(k), -1)
+func (match *Match) print(out io.Writer, diff bool) {
+	if diff == true {
+		fmt.Fprintf(out, "%s> %s = %s\n", match.path, match.keyLineDiff, match.valueLineDiff)
+	} else {
+		fmt.Fprintf(out, "%s> %s = %s\n", match.path, match.highlightMatches(match.key, match.keyIndex), match.highlightMatches(match.value, match.valueIndex))
 	}
-	valueMatches := make([][]int, 0)
-	if s.IsMode(ModeValues) {
-		valueMatches = s.regexp.FindAllIndex([]byte(v), -1)
-	}
+}
 
-	if len(keyMatches) > 0 || len(valueMatches) > 0 {
-		m = []*Match{
-			{
-				path:       path,
-				term:       s.regexp.String(),
-				key:        k,
-				value:      v,
-				keyIndex:   keyMatches,
-				valueIndex: valueMatches,
-			},
+// highlightMatches will take an array of index and lens and highlight them
+func (match *Match) highlightMatches(s string, matches [][]int) (result string) {
+	cur := 0
+	if len(matches) > 0 {
+		for _, pair := range matches {
+			next := pair[0]
+			length := pair[1]
+			end := next + length
+			result += s[cur:next]
+			result += color.New(color.FgYellow).SprintFunc()(s[next:end])
+			cur = end
+		}
+		result += s[cur:]
+	} else {
+		return s
+	}
+	return result
+}
+
+// highlightLineDiff will consume (~~del~~)(++add++) markup and colorize in its place
+func (s *Searcher) highlightLineDiff(d string) string {
+	var buf, res []byte
+	removeMode, addMode := false, false
+	removeColor := color.New(color.FgWhite).Add(color.BgRed)
+	addColor := color.New(color.FgWhite).Add(color.BgGreen)
+
+	for _, b := range []byte(d) {
+		buf = append(buf, b)
+		if string(buf) == "(~~" && !removeMode && !addMode {
+			buf = make([]byte, 0)
+			removeMode = true
+		} else if len(buf) > 3 && string(buf[len(buf)-3:]) == "~~)" && removeMode {
+			res = append(res, removeColor.SprintFunc()(string(buf[0:len(buf)-3]))...)
+			buf = make([]byte, 0)
+			removeMode = false
+		} else if string(buf) == "(++" && !removeMode && !addMode {
+			buf = make([]byte, 0)
+			addMode = true
+		} else if len(buf) > 3 && string(buf[len(buf)-3:]) == "++)" && addMode {
+			res = append(res, addColor.SprintFunc()(string(buf[0:len(buf)-3]))...)
+			buf = make([]byte, 0)
+			addMode = false
 		}
 	}
-	return m
+	return string(append(res, buf...))
+}
+
+func (s *Searcher) matchData(subject string, isRegexp bool) (matchPairs [][]int, replaced string, inlineDiff string) {
+	replaced, inlineDiff = subject, subject
+	matchPairs = make([][]int, 0)
+
+	if isRegexp {
+		matchPairs = s.regexp.FindAllIndex([]byte(subject), -1)
+	} else {
+		index := suffixarray.New([]byte(subject))
+		matches := index.Lookup([]byte(s.cmd.GetSearchParams().Search), -1)
+		sort.Ints(matches)
+		substrLength := len(s.cmd.GetSearchParams().Search)
+		for _, offset := range matches {
+			matchPairs = append(matchPairs, []int{offset, substrLength})
+		}
+	}
+
+	if s.cmd.GetSearchParams().Replacement != nil {
+		if isRegexp {
+			replaced = s.regexp.ReplaceAllString(subject, *s.cmd.GetSearchParams().Replacement)
+		} else {
+			replaced = strings.ReplaceAll(subject, s.cmd.GetSearchParams().Search, *s.cmd.GetSearchParams().Replacement)
+		}
+		inlineDiff = s.highlightLineDiff(diff.CharacterDiff(subject, replaced))
+	}
+	return matchPairs, replaced, inlineDiff
 }

--- a/cli/search.go
+++ b/cli/search.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"fmt"
+	"index/suffixarray"
+	"regexp"
+	"sort"
+)
+
+// SearchingCommand interface to describe a command that performs a search operation
+type SearchingCommand interface {
+  GetSearchParams() SearchParameters
+}
+
+type SearchParameters struct {
+	Search      string
+	Replacement string
+	Mode        KeyValueMode
+  doRegexp bool
+}
+
+// Match structure to keep indices of matched terms
+type Match struct {
+	path  string
+	term  string
+	key   string
+	value string
+	// sorted slices of indices of match starts and length
+	keyIndex   [][]int
+	valueIndex [][]int
+}
+
+type Searcher struct {
+	cmd    SearchingCommand
+	regexp *regexp.Regexp
+}
+
+// NewSearcher creates a new Searcher container for performing search and optionally replace
+func NewSearcher(cmd SearchingCommand) (*Searcher, error) {
+	var re *regexp.Regexp
+	var err error
+	params := cmd.GetSearchParams()
+
+	if params.doRegexp {
+		re, err = regexp.Compile(params.Search)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse regex pattern")
+		}
+	}
+
+	return &Searcher{cmd: cmd, regexp: re}, nil
+}
+
+// IsMode returns true if the specified mode is enabled
+func (s *Searcher) IsMode(mode KeyValueMode) bool {
+	return s.cmd.GetSearchParams().Mode&mode == mode
+}
+
+func (s *Searcher) DoMatch(path string, k string, v string) (m []*Match) {
+	if s.regexp != nil {
+		return s.regexpMatch(path, k, v)
+	}
+	return s.substrMatch(path, k, v)
+}
+
+// find all indices for matches in key and value
+func (s *Searcher) substrMatch(path string, k string, v string) (m []*Match) {
+	substrLength := len(s.cmd.GetSearchParams().Search)
+	keyMatchPairs := make([][]int, 0)
+	if s.IsMode(ModeKeys) {
+		keyIndex := suffixarray.New([]byte(k))
+		keyMatches := keyIndex.Lookup([]byte(s.cmd.GetSearchParams().Search), -1)
+		sort.Ints(keyMatches)
+		for _, offset := range keyMatches {
+			keyMatchPairs = append(keyMatchPairs, []int{offset, substrLength})
+		}
+	}
+
+	valueMatchPairs := make([][]int, 0)
+	if s.IsMode(ModeValues) {
+		valueIndex := suffixarray.New([]byte(v))
+		valueMatches := valueIndex.Lookup([]byte(s.cmd.GetSearchParams().Search), -1)
+		sort.Ints(valueMatches)
+		for _, offset := range valueMatches {
+			valueMatchPairs = append(valueMatchPairs, []int{offset, substrLength})
+		}
+	}
+
+	if len(keyMatchPairs) > 0 || len(valueMatchPairs) > 0 {
+		m = []*Match{
+			{
+				path:       path,
+				term:       s.cmd.GetSearchParams().Search,
+				key:        k,
+				value:      v,
+				keyIndex:   keyMatchPairs,
+				valueIndex: valueMatchPairs,
+			},
+		}
+	}
+	return m
+}
+
+func (s *Searcher) regexpMatch(path string, k string, v string) (m []*Match) {
+	keyMatches := make([][]int, 0)
+	if s.IsMode(ModeKeys) {
+		keyMatches = s.regexp.FindAllIndex([]byte(k), -1)
+	}
+	valueMatches := make([][]int, 0)
+	if s.IsMode(ModeValues) {
+		valueMatches = s.regexp.FindAllIndex([]byte(v), -1)
+	}
+
+	if len(keyMatches) > 0 || len(valueMatches) > 0 {
+		m = []*Match{
+			{
+				path:       path,
+				term:       s.regexp.String(),
+				key:        k,
+				value:      v,
+				keyIndex:   keyMatches,
+				valueIndex: valueMatches,
+			},
+		}
+	}
+	return m
+}

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -165,6 +167,21 @@ func (client *Client) Traverse(absolutePath string) (paths []string) {
 	}
 
 	return paths
+}
+
+// SubpathsForPath will return an array of absolute paths at or below path
+func (client *Client) SubpathsForPath(path string) (filePaths []string, err error) {
+	switch t := client.GetType(path); t {
+	case LEAF:
+		filePaths = append(filePaths, filepath.Clean(path))
+	case NODE:
+		for _, traversedPath := range client.Traverse(path) {
+			filePaths = append(filePaths, traversedPath)
+		}
+	default:
+		return filePaths, fmt.Errorf("Not a valid path for operation: %s", path)
+	}
+	return filePaths, nil
 }
 
 // ClearCache clears the list cache

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -127,14 +127,15 @@ func isCommand(p string) bool {
 
 func (c *Completer) commandSuggestions(arg string) (result []prompt.Suggest) {
 	result = []prompt.Suggest{
+		{Text: "append", Description: "append <from> <to> [-f|--force] | [-s|--skip] | [-r|--rename] | -s is default"},
+		{Text: "cat", Description: "cat <path>"},
 		{Text: "cd", Description: "cd <path>"},
 		{Text: "cp", Description: "cp <from> <to> | -r is implied"},
-		{Text: "append", Description: "append <from> <to> [-f|--force] | [-s|--skip] | [-r|--rename] | -s is default"},
-		{Text: "rm", Description: "rm <path> | -r is implied"},
-		{Text: "mv", Description: "mv <from> <to>"},
 		{Text: "grep", Description: "grep <search> <path> [-e|--regexp] [-k|--keys] [-v|--values]"},
-		{Text: "cat", Description: "cat <path>"},
 		{Text: "ls", Description: "ls <path>"},
+		{Text: "mv", Description: "mv <from> <to>"},
+		{Text: "replace", Description: "replace <search> <replacement> <path> [-e|--regexp] [-k|--keys] [-v|--values] [-y|--confirm] [-n|--dry-run]"},
+		{Text: "rm", Description: "rm <path> | -r is implied"},
 		{Text: "toggle-auto-completion", Description: "toggle path auto-completion on/off"},
 	}
 	filtered := prompt.FilterHasPrefix(result, arg, true)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/fishi0x01/vsh
 go 1.12
 
 require (
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/c-bata/go-prompt v0.2.3
+	github.com/cnlubo/promptx v0.0.0-20190626092511-0fff67c60c75
 	github.com/fatih/color v1.7.0
 	github.com/hashicorp/vault v1.3.3
 	github.com/hashicorp/vault/api v1.0.5-0.20200117231345-460d63e36490
@@ -11,4 +13,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f h1:oRD
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f/go.mod h1:myCDvQSzCW+wB1WAlocEru4wMGJxy+vlxHdhegi1CDQ=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5 h1:nWDRPCyCltiTsANwC/n3QZH7Vww33Npq9MKqlwRzI/c=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apple/foundationdb/bindings/go v0.0.0-20190411004307-cd5c9d91fad2 h1:VoHKYIXEQU5LWoambPBOvYxyLqZYHuj+rj5DVnMUc3k=
@@ -83,6 +85,8 @@ github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f h1:gJzxr
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
 github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0 h1:CWU8piLyqoi9qXEUwzOh5KFKGgmSU5ZhktJyYcq6ryQ=
 github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0/go.mod h1:5d8DqS60xkj9k3aXfL3+mXBH0DPYO0FQjcKosxl+b/Q=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
@@ -90,6 +94,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381 h1:rdRS5BT13Iae9ssvcslol66gfOOXjaLYwqerEn/cl9s=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20190201205600-f136f9222381/go.mod h1:e5+USP2j8Le2M0Jo3qKPFnNhuo1wueU4nWHCXBOfQ14=
+github.com/cnlubo/promptx v0.0.0-20190626092511-0fff67c60c75 h1:dGpbTw8/7dd4iuqbSEuD3ERyuUwmpmEiS+yk93TpquE=
+github.com/cnlubo/promptx v0.0.0-20190626092511-0fff67c60c75/go.mod h1:W+qEaMR24ZkcayRYX0MiYyKZ46b9hKfytZ5RxXFixiY=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c h1:2zRrJWIt/f9c9HhNHAgrRgq0San5gRRUJTBXLkchal0=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
@@ -456,8 +462,11 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mritd/readline v0.0.0-20190430155141-1af16399dc52 h1:LtfLwyq20tlA4EZ/rF2JKG/ccNBZzfwOJZ72uPTqhlQ=
+github.com/mritd/readline v0.0.0-20190430155141-1af16399dc52/go.mod h1:9er/6+nnOsC7xIZIbVOZ40teP1ph7ei4OY6xLzuktOY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ncw/swift v1.0.47 h1:4DQRPj35Y41WogBxyhOXlrI37nzGlyEcsforeudyYPQ=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
@@ -537,6 +546,8 @@ github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec/go.mod h1:gi+0
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v2.19.9+incompatible h1:IrPVlK4nfwW10DF7pW+7YJKws9NkgNzWozwwWv9FsgY=
 github.com/shirou/gopsutil v2.19.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
@@ -560,6 +571,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
@@ -664,11 +676,13 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqYSEQ0KWqdWLu3xuZJts=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190730183949-1393eb018365/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
@@ -732,6 +746,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
@@ -752,6 +767,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -147,6 +147,9 @@ func getCommand(args []string, commands *cli.Commands) (cmd cli.Command, err err
 	case commands.Grep.GetName():
 		err = commands.Grep.Parse(args)
 		cmd = commands.Grep
+	case commands.Replace.GetName():
+		err = commands.Replace.Parse(args)
+		cmd = commands.Replace
 	default:
 		log.UserError("Not a valid command: %s", args[0])
 		return nil, fmt.Errorf("not a valid command")

--- a/test/suites/commands/replace.bats
+++ b/test/suites/commands/replace.bats
@@ -1,0 +1,14 @@
+load ../../util/util
+load ../../bin/plugins/bats-support/load
+load ../../bin/plugins/bats-assert/load
+
+@test "vault-${VAULT_VERSION} ${KV_BACKEND} 'replace'" {
+  #######################################
+  echo "==== case: replace content in single file ===="
+  run ${APP_BIN} -c "replace --value 'apple' 'something' ${KV_BACKEND}/src/dev/1"
+  assert_success
+  
+  echo "ensure value(s) got replaced"
+  run get_vault_value "fruit" "${KV_BACKEND}/src/dev/1"
+  assert_line "fruit = something"
+}

--- a/test/suites/commands/replace.bats
+++ b/test/suites/commands/replace.bats
@@ -4,11 +4,96 @@ load ../../bin/plugins/bats-assert/load
 
 @test "vault-${VAULT_VERSION} ${KV_BACKEND} 'replace'" {
   #######################################
-  echo "==== case: replace content in single file ===="
-  run ${APP_BIN} -c "replace --value 'apple' 'something' ${KV_BACKEND}/src/dev/1"
+  echo "==== case: replace nonexistant string ===="
+  run ${APP_BIN} -c "replace 'foobarbaz' 'pie' ${KV_BACKEND}/src/dev/1 -y"
   assert_success
-  
-  echo "ensure value(s) got replaced"
+  assert_line "No matches found to replace."
+
+  #######################################
+  echo "==== case: replace in dry-run ===="
+  run ${APP_BIN} -c "replace 'fruit' 'pie' ${KV_BACKEND}/src/dev/1 -y -n"
+  assert_success
+  assert_line "Skipping write."
   run get_vault_value "fruit" "${KV_BACKEND}/src/dev/1"
-  assert_line "fruit = something"
+  assert_line apple
+
+  #######################################
+  echo "==== case: replace value with empty string ===="
+  run ${APP_BIN} -c "replace 'beer' '' ${KV_BACKEND}/src/tooling -y"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "drink" "${KV_BACKEND}/src/tooling"
+  refute_line beer
+
+  #######################################
+  echo "==== case: replace key in single path without scope ===="
+  run ${APP_BIN} -c "replace 'fruit' 'pie' ${KV_BACKEND}/src/dev/1 -y"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "pie" "${KV_BACKEND}/src/dev/1"
+  assert_line apple
+
+  #######################################
+  echo "==== case: replace value in single path without scope ===="
+  run ${APP_BIN} -c "replace 'banana' 'something' ${KV_BACKEND}/src/dev/2 -y"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "fruit" "${KV_BACKEND}/src/dev/2"
+  assert_line something
+
+  #######################################
+  echo "==== case: replace key in single path with scope ===="
+  run ${APP_BIN} -c "replace 'tree' 'flora' ${KV_BACKEND}/src/staging/all -k -y"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "flora" "${KV_BACKEND}/src/staging/all"
+  assert_line palm
+
+  #######################################
+  echo "==== case: replace value in single path with scope ===="
+  run ${APP_BIN} -c "replace 'test' 'exhibit' ${KV_BACKEND}/src/prod/all -v -y"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "example" "${KV_BACKEND}/src/prod/all"
+  assert_line exhibit
+}
+
+@test "vault-${VAULT_VERSION} ${KV_BACKEND} 'replace' regexp" {
+  #######################################
+  echo "==== case: replace nonexistant string ===="
+  run ${APP_BIN} -c "replace '^ruit' 'pie' ${KV_BACKEND}/src/dev/1 -y -e"
+  assert_success
+  assert_line "No matches found to replace."
+
+  #######################################
+  echo "==== case: replace key in single path without scope ===="
+  run ${APP_BIN} -c "replace '^fru.*' 'pie' ${KV_BACKEND}/src/dev/1 -y -e"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "pie" "${KV_BACKEND}/src/dev/1"
+  assert_line apple
+
+  #######################################
+  echo "==== case: replace value in single path without scope ===="
+  run ${APP_BIN} -c "replace '[ba]+nana' 'something' ${KV_BACKEND}/src/dev/2 -y -e"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "fruit" "${KV_BACKEND}/src/dev/2"
+  assert_line something
+
+  #######################################
+  echo "==== case: replace key in single path with scope ===="
+  run ${APP_BIN} -c "replace 'tre{2}' 'flora' ${KV_BACKEND}/src/staging/all -k -y -e"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "flora" "${KV_BACKEND}/src/staging/all"
+  assert_line palm
+
+  #######################################
+  echo "==== case: replace value in single path with scope ===="
+  run ${APP_BIN} -c "replace '(test)' '\${1}exhibit' ${KV_BACKEND}/src/prod/all -v -y -e"
+  assert_success
+  assert_line "Writing!"
+  run get_vault_value "example" "${KV_BACKEND}/src/prod/all"
+  assert_line testexhibit
 }

--- a/test/suites/commands/replace.bats
+++ b/test/suites/commands/replace.bats
@@ -24,6 +24,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "drink" "${KV_BACKEND}/src/tooling"
   refute_line beer
+  run get_vault_value "key" "${KV_BACKEND}/src/tooling"
+  assert_line A
 
   #######################################
   echo "==== case: replace key in single path without scope ===="
@@ -32,6 +34,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "pie" "${KV_BACKEND}/src/dev/1"
   assert_line apple
+  run get_vault_value "value" "${KV_BACKEND}/src/dev/1"
+  assert_line 1
 
   #######################################
   echo "==== case: replace value in single path without scope ===="
@@ -40,6 +44,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "fruit" "${KV_BACKEND}/src/dev/2"
   assert_line something
+  run get_vault_value "value" "${KV_BACKEND}/src/dev/2"
+  assert_line 2
 
   #######################################
   echo "==== case: replace key in single path with scope ===="
@@ -56,6 +62,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "example" "${KV_BACKEND}/src/prod/all"
   assert_line exhibit
+  run get_vault_value "value" "${KV_BACKEND}/src/prod/all"
+  assert_line all
 }
 
 @test "vault-${VAULT_VERSION} ${KV_BACKEND} 'replace' regexp" {
@@ -72,6 +80,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "pie" "${KV_BACKEND}/src/dev/1"
   assert_line apple
+  run get_vault_value "value" "${KV_BACKEND}/src/dev/1"
+  assert_line 1
 
   #######################################
   echo "==== case: replace value in single path without scope ===="
@@ -80,6 +90,8 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "fruit" "${KV_BACKEND}/src/dev/2"
   assert_line something
+  run get_vault_value "value" "${KV_BACKEND}/src/dev/2"
+  assert_line 2
 
   #######################################
   echo "==== case: replace key in single path with scope ===="
@@ -96,4 +108,6 @@ load ../../bin/plugins/bats-assert/load
   assert_line "Writing!"
   run get_vault_value "example" "${KV_BACKEND}/src/prod/all"
   assert_line testexhibit
+  run get_vault_value "value" "${KV_BACKEND}/src/prod/all"
+  assert_line all
 }

--- a/test/suites/edge-cases/print-version.bats
+++ b/test/suites/edge-cases/print-version.bats
@@ -4,8 +4,8 @@ load ../../bin/plugins/bats-assert/load
 
 @test "vault-${VAULT_VERSION} - print client version" {
   #######################################
-  export BIN_VERSION=$(git describe --tags --always --dirty)
   echo "==== case: print client version ===="
+  export BIN_VERSION=$(git describe --tags --always --dirty)
   run ${APP_BIN} -version
   assert_success
   assert_line "${BIN_VERSION}"

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -68,9 +68,13 @@ teardown() {
 }
 
 vault_exec() {
-    docker exec ${VAULT_CONTAINER_NAME} /bin/sh -c "$1" &> /dev/null
+    vault_exec_output "$@" &> /dev/null
+}
+
+vault_exec_output() {
+    docker exec ${VAULT_CONTAINER_NAME} /bin/sh -c "$1"
 }
 
 get_vault_value() {
-    docker exec ${VAULT_CONTAINER_NAME} vault kv get -field="${1}" "${2}" || true
+    vault_exec_output "vault kv get -field=\"${1}\" \"${2}\" || true"
 }


### PR DESCRIPTION
The `replace` command will do a match in the same fashion as `grep` but instead of presenting results with search patterns highlighted, it will highlight matches in red followed immediately by replacement string in green. In this way, it is easy to identify on one line what will be matched and replaced. by default, the operation will ask for confirmation before writing back to vault. it is possible to use flags `-y` to write without confirmation, `-n` to skip confirmation and not write aka dry-run, and limit scope to keys (`-k`) and values (`-v`) in the same way as in `grep`.

Moves search functions to its own file and provides a struct common for search/replace operations. The struct is embedded with commands that utilize search so that the commands contain the search paramters and the commands implement an interface for retrieving the parameters. This allows common methods to be located on a `Searcher` struct that can reference the command via the interface.

<img width="570" alt="Screen Shot 2021-02-01 at 21 34 38" src="https://user-images.githubusercontent.com/739851/106553418-9aee0080-64d6-11eb-8679-6979844abc73.png">

There's a lot of fat that can be trimmed from this implementation. I'm not super happy with it, but I think this is the kind of functionality I originally envisioned with #59 . I think in the future, it'd be nice to give the option of a traditional diff display instead of strictly inline color highlighting.