### PR TITLE
refactor args parsing with go-arg library

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"bytes"
+
+	"github.com/alexflint/go-arg"
+)
+
+func parseCommandArgs(args []string, cmd Command) (*arg.Parser, error) {
+	p, err := argParser(args, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(args) > 1 {
+		err = p.Parse(args[1:])
+	} else {
+		err = p.Parse([]string{})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func argParser(args []string, cmd Command) (*arg.Parser, error) {
+	return arg.NewParser(arg.Config{Program: args[0]}, cmd.GetArgs())
+}
+
+// Usage returns usage information
+func Usage(cmd Command) string {
+	var b bytes.Buffer
+	p, _ := argParser([]string{cmd.GetName()}, cmd)
+	p.WriteUsage(&b)
+	return b.String()
+}
+
+// Help returns extended usage information
+func Help(cmd Command) string {
+	var b bytes.Buffer
+	p, _ := argParser([]string{cmd.GetName()}, cmd)
+	p.WriteHelp(&b)
+	return b.String()
+}

--- a/cli/rm.go
+++ b/cli/rm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/fishi0x01/vsh/client"
 	"github.com/fishi0x01/vsh/log"
 )
@@ -9,9 +10,19 @@ import (
 // RemoveCommand container for all 'rm' parameters
 type RemoveCommand struct {
 	name string
+	args *RemoveCommandArgs
 
 	client *client.Client
-	Path   string
+}
+
+// RemoveCommandArgs provides a struct for go-arg parsing
+type RemoveCommandArgs struct {
+	Path string `arg:"positional,required" help:"path to remove"`
+}
+
+// Description provides detail on what the command does
+func (RemoveCommandArgs) Description() string {
+	return "removes a secret at a path"
 }
 
 // NewRemoveCommand creates a new RemoveCommand parameter container
@@ -19,6 +30,7 @@ func NewRemoveCommand(c *client.Client) *RemoveCommand {
 	return &RemoveCommand{
 		name:   "rm",
 		client: c,
+		args:   &RemoveCommandArgs{},
 	}
 }
 
@@ -27,28 +39,34 @@ func (cmd *RemoveCommand) GetName() string {
 	return cmd.name
 }
 
+// GetArgs provides the struct holding arguments for the command
+func (cmd *RemoveCommand) GetArgs() interface{} {
+	return cmd.args
+}
+
 // IsSane returns true if command is sane
 func (cmd *RemoveCommand) IsSane() bool {
-	return cmd.Path != ""
+	return cmd.args.Path != ""
 }
 
 // PrintUsage print command usage
 func (cmd *RemoveCommand) PrintUsage() {
-	log.UserInfo("Usage:\nrm <path>")
+	fmt.Println(Help(cmd))
 }
 
 // Parse given arguments and return status
 func (cmd *RemoveCommand) Parse(args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("cannot parse arguments")
+	_, err := parseCommandArgs(args, cmd)
+	if err != nil {
+		return err
 	}
-	cmd.Path = args[1]
+
 	return nil
 }
 
 // Run executes 'rm' with given RemoveCommand's parameters
 func (cmd *RemoveCommand) Run() int {
-	newPwd := cmdPath(cmd.client.Pwd, cmd.Path)
+	newPwd := cmdPath(cmd.client.Pwd, cmd.args.Path)
 
 	switch t := cmd.client.GetType(newPwd); t {
 	case client.LEAF:

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,13 @@ module github.com/fishi0x01/vsh
 go 1.12
 
 require (
+	github.com/alexflint/go-arg v1.3.0
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/c-bata/go-prompt v0.2.3
 	github.com/cnlubo/promptx v0.0.0-20190626092511-0fff67c60c75
+	github.com/cosiner/argv v0.1.0
 	github.com/fatih/color v1.7.0
+	github.com/fatih/structs v1.1.0
 	github.com/hashicorp/vault v1.3.3
 	github.com/hashicorp/vault/api v1.0.5-0.20200117231345-460d63e36490
 	github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,10 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexflint/go-arg v1.3.0 h1:UfldqSdFWeLtoOuVRosqofU4nmhI1pYEbT4ZFS34Bdo=
+github.com/alexflint/go-arg v1.3.0/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
+github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190412020505-60e2075261b6/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f h1:oRD16bhpKNAanfcDDVU+J0NXqsgHIvGbbe/sy+r6Rs0=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f/go.mod h1:myCDvQSzCW+wB1WAlocEru4wMGJxy+vlxHdhegi1CDQ=
@@ -110,6 +114,8 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d h1:t5Wuyh53qYyg9
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf h1:CAKfRE2YtTUIjjh1bkBtyYFaUT/WmOqsJjgtihT0vMI=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cosiner/argv v0.1.0 h1:BVDiEL32lwHukgJKP87btEPenzrrHUjajs/8yzaqcXg=
+github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/test/suites/commands/grep.bats
+++ b/test/suites/commands/grep.bats
@@ -87,7 +87,7 @@ load ../../bin/plugins/bats-assert/load
   #######################################
   echo "==== case: fails on invalid flag ===="
   run ${APP_BIN} -c "grep 'apple' ${KV_BACKEND}/src/dev --foo"
-  assert_line --partial "invalid flag"
+  assert_line --partial "unknown argument --foo"
   assert_failure 1
 
   #######################################

--- a/test/suites/edge-cases/false-commands.bats
+++ b/test/suites/edge-cases/false-commands.bats
@@ -6,7 +6,8 @@ load ../../bin/plugins/bats-assert/load
   #######################################
   echo "==== case: non-existing flag ===="
   run ${APP_BIN} -x not
-  assert_failure 2
+  assert_line --partial "unknown argument -x"
+  assert_failure 255
 
   echo "==== case: non-existing command ===="
   run ${APP_BIN} -c "nono xD"

--- a/test/suites/edge-cases/logging.bats
+++ b/test/suites/edge-cases/logging.bats
@@ -22,7 +22,7 @@ load ../../bin/plugins/bats-file/load
 
   echo "==== case: invalid verbosity level ===="
   run bash -c "VAULT_TOKEN=delete-only ${APP_BIN} -v NOTEXIST -c 'ls /KV2/src/a'"
-  assert_failure 1
+  assert_failure 255
   assert_line --partial "Not a valid verbosity level"
 
   echo "==== case: login with false token ===="

--- a/test/suites/edge-cases/print-version.bats
+++ b/test/suites/edge-cases/print-version.bats
@@ -6,7 +6,7 @@ load ../../bin/plugins/bats-assert/load
   #######################################
   echo "==== case: print client version ===="
   export BIN_VERSION=$(git describe --tags --always --dirty)
-  run ${APP_BIN} -version
+  run ${APP_BIN} --version
   assert_success
   assert_line "${BIN_VERSION}"
 }


### PR DESCRIPTION
This pull refactors all command argument parsing so that flags can be mixed with positional arguments in commands.

- implement go-arg for parsing in main
- convert all commands to use go-args for arg parsing
- add descriptions to commands
- dynamically populate auto-complete with commands and usage info
- removes the need to modify completer.go when adding or updating commands

<img width="925" alt="Screen Shot 2021-02-04 at 22 35 37" src="https://user-images.githubusercontent.com/739851/106994091-5a41f180-6739-11eb-95cd-58fd20eadf5d.png">

Fixes #71 

This will also allow me to be able to take a string argument for #72 

Zero maintenance help for both main and subcommand completion.

```
➜ build/vsh_darwin_amd64 -h    
vsh - Shell for Hashicorp Vault
v0.7.2-10-g3ad5080
Usage: vsh_darwin_amd64 [--cmd CMD] [--disable-auto-completion] [--log-level LEVEL]

Options:
  --cmd CMD, -c CMD      subcommand to run
  --disable-auto-completion
                         disable auto-completion on paths
  --log-level LEVEL, -v LEVEL
                         DEBUG | INFO | WARN | ERROR - debug option creates vsh_trace.log [default: INFO]
  --help, -h             display this help and exit
  --version              display version and exit
```

```
➜ build/vsh_darwin_amd64 -c 'append'                                              
source is required
appends the contents of one secret to another
Usage: append [--force] [--skip] [--rename] SOURCE TARGET

Positional arguments:
  SOURCE
  TARGET

Options:
  --force, -f            Overwrite key if exists
  --skip, -s             Skip key if exists (default)
  --rename, -r           Rename key if exists
  --help, -h             display this help and exit
```