### PR TITLE
Fix no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## master - unreleased
+
+BUG FIXES:
+
+* Don't show error on empty line enter in interactive mode ([#85](https://github.com/fishi0x01/vsh/pull/85))
+
 ## v0.9.0 (February 6, 2021)
 
 Big thank you to [mattlqx](https://github.com/mattlqx) for the great enhancements.

--- a/main.go
+++ b/main.go
@@ -48,12 +48,6 @@ func executor(in string) {
 	args, err := argv.Argv(in, func(backquoted string) (string, error) {
 		return backquoted, nil
 	}, nil)
-	if err != nil {
-		log.UserError("%v", err)
-		return
-	}
-	commands := cli.NewCommands(vaultClient)
-	var cmd cli.Command
 
 	// edge cases
 	if len(args) == 0 {
@@ -63,6 +57,13 @@ func executor(in string) {
 		}
 		return
 	}
+
+	if err != nil {
+		log.UserError("%v", err)
+		return
+	}
+	commands := cli.NewCommands(vaultClient)
+	var cmd cli.Command
 
 	// parse command
 	switch args[0][0] {


### PR DESCRIPTION
Currently, return on blank line shows an error in interactive mode:

```
http://localhost:8888 />                                                                                                                                                                                   
invalid syntax                                                                                                                                                                                             
http://localhost:8888 />
```

This PR fixes behavior to previous to allow enter on empty line:
```
http://localhost:8888 />                                                                                                                                                                                                                                                                                                                                                                          
http://localhost:8888 />
```