### PR TITLE
Concurrency for traversal

### DIFF
--- a/cli/rm.go
+++ b/cli/rm.go
@@ -72,7 +72,9 @@ func (cmd *RemoveCommand) Run() int {
 	case client.LEAF:
 		cmd.removeSecret(newPwd)
 	case client.NODE:
-		for _, path := range cmd.client.Traverse(newPwd) {
+		c := make(chan string, 10)
+		go cmd.client.Traverse(newPwd, c)
+		for path := range c {
 			err := cmd.removeSecret(path)
 			if err != nil {
 				return 1


### PR DESCRIPTION
:warning: This is still work in progress. 

This addresses https://github.com/fishi0x01/vsh/issues/78
Use fixed number of worker threads to apply operations on traversed paths. 
- `Traverse` pushes paths to go channel
- `runCommandWithTraverseTwoPaths` uses worker threads which consume the above channel

Currently, only `rm`, `mv` and `cp` profit from this. 