### PR TITLE
add output formatting option for replace command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master - unreleased
 
+ENHANCEMENTS:
+
+* Add `--output` flag to `replace` command to output as line diffs for each replacement in addition to the default inline format. ([#88](https://github.com/fishi0x01/vsh/pull/88))
+
 BUG FIXES:
 
 * Don't show error on empty line enter in interactive mode ([#85](https://github.com/fishi0x01/vsh/pull/85))

--- a/cli/grep.go
+++ b/cli/grep.go
@@ -101,7 +101,7 @@ func (cmd *GrepCommand) Run() int {
 			return 1
 		}
 		for _, match := range matches {
-			match.print(os.Stdout, false)
+			match.print(os.Stdout, MatchOutputHighlight)
 		}
 	}
 	return 0

--- a/cli/replace.go
+++ b/cli/replace.go
@@ -21,15 +21,16 @@ type ReplaceCommand struct {
 
 // ReplaceCommandArgs provides a struct for go-arg parsing
 type ReplaceCommandArgs struct {
-	Search      string `arg:"positional,required"`
-	Replacement string `arg:"positional,required"`
-	Path        string `arg:"positional,required"`
-	Regexp      bool   `arg:"-e,--regexp" help:"Treat search string and selector as a regexp"`
-	KeySelector string `arg:"-s,--key-selector" help:"Limit replacements to specified key" placeholder:"PATTERN"`
-	Keys        bool   `arg:"-k,--keys" help:"Match against keys (true if -v is not specified)"`
-	Values      bool   `arg:"-v,--values" help:"Match against values (true if -k is not specified)"`
-	Confirm     bool   `arg:"-y,--confirm" help:"Write results without prompt"`
-	DryRun      bool   `arg:"-n,--dry-run" help:"Skip writing results without prompt"`
+	Search      string         `arg:"positional,required"`
+	Replacement string         `arg:"positional,required"`
+	Path        string         `arg:"positional,required"`
+	Regexp      bool           `arg:"-e,--regexp" help:"Treat search string and selector as a regexp"`
+	KeySelector string         `arg:"-s,--key-selector" help:"Limit replacements to specified key" placeholder:"PATTERN"`
+	Keys        bool           `arg:"-k,--keys" help:"Match against keys (true if -v is not specified)"`
+	Values      bool           `arg:"-v,--values" help:"Match against values (true if -k is not specified)"`
+	Confirm     bool           `arg:"-y,--confirm" help:"Write results without prompt"`
+	DryRun      bool           `arg:"-n,--dry-run" help:"Skip writing results without prompt"`
+	Output      MatchOutputArg `arg:"-o,--output" help:"Present changes as 'inline' with color or traditional 'diff'" default:"inline"`
 }
 
 // Description provides detail on what the command does
@@ -72,6 +73,7 @@ func (cmd *ReplaceCommand) GetSearchParams() SearchParameters {
 		IsRegexp:    cmd.args.Regexp,
 		KeySelector: cmd.args.KeySelector,
 		Mode:        cmd.Mode,
+		Output:      cmd.args.Output.Value,
 		Replacement: &cmd.args.Replacement,
 		Search:      cmd.args.Search,
 	}
@@ -130,7 +132,7 @@ func (cmd *ReplaceCommand) findMatches(filePaths []string) (matchesByPath map[st
 			return matchesByPath, err
 		}
 		for _, match := range matches {
-			match.print(os.Stdout, true)
+			match.print(os.Stdout, cmd.args.Output.Value)
 		}
 		if len(matches) > 0 {
 			_, ok := matchesByPath[curPath]

--- a/doc/commands/replace.md
+++ b/doc/commands/replace.md
@@ -1,3 +1,7 @@
 # replace
 
 `replace` works similarly to `grep`, but has the ability to mutate data inside Vault. By default, confirmation is required before writing data. You may skip confirmation by using the `-y`/`--confirm` flags. Conversely, you may use the `-n`/`--dry-run` flags to skip both confirmation and any writes. Changes that would be made are presented in red (delete) and green (add) coloring.
+
+This command has two output formats available via the `--output` flag:
+- `inline`: A colorized inline format where deletions are in red background text and additions are in green background text. This is the default.
+- `diff`: A non-colorized format that prints changes in two lines prefixed with a `-` for before and `+` for after replacement. This is more useful for copying and pasting the result.

--- a/test/suites/commands/replace.bats
+++ b/test/suites/commands/replace.bats
@@ -67,6 +67,19 @@ load ../../bin/plugins/bats-assert/load
   assert_line all
 
   #######################################
+  echo "==== case: replace with invalid output format ===="
+  run ${APP_BIN} -c "replace -s 'produce' 'apple' 'orange' ${KV_BACKEND}/src/selector/1 -o invalid"
+  assert_failure
+  assert_line --partial "invalid output format: invalid"
+
+  #######################################
+  echo "==== case: replace with diff output format ===="
+  run ${APP_BIN} -c "replace -s 'produce' 'apple' 'orange' ${KV_BACKEND}/src/selector/1 -n -o diff"
+  assert_success
+  assert_line "- /${KV_BACKEND}/src/selector/1> produce = apple"
+  assert_line "+ /${KV_BACKEND}/src/selector/1> produce = orange"
+
+  #######################################
   echo "==== case: replace value in single path with selector ===="
   run ${APP_BIN} -c "replace -s 'produce' 'apple' 'orange' ${KV_BACKEND}/src/selector/1 -y"
   assert_success


### PR DESCRIPTION
my co-worker noted that its hard to share pastes of the replace commands dry-run output because its colorized. supporting a two-line output of changes with +/- prefixed to denote addition and subtraction for each change is better formatted for sharing.

```
➜ build/vsh_darwin_amd64 -c 'replace -k value myValue KV1/src/a/foo -n'
/KV1/src/a/foo> vmyValue = 1
Skipping write.

➜ build/vsh_darwin_amd64 -c 'replace -k value myValue KV1/src/a/foo -n -o diff'
- /KV1/src/a/foo> value = 1
+ /KV1/src/a/foo> myValue = 1
Skipping write.

```
