### PR TITLE
Adding dry-run/confirm flags to the 'add' command

### DIFF
--- a/doc/commands/add.md
+++ b/doc/commands/add.md
@@ -1,7 +1,7 @@
 # add
 
 ```text
-add [-f|--force] [-y|--commit] [-n|--dry-run] KEY VALUE PATH
+add [-f|--force] [-y|--confirm] [-n|--dry-run] KEY VALUE PATH
 ```
 
 Add operation adds or overwrites a single key at path.

--- a/doc/commands/add.md
+++ b/doc/commands/add.md
@@ -1,7 +1,7 @@
 # add
 
 ```text
-add [-f|--force] KEY VALUE PATH
+add [-f|--force] [-y|--commit] [-n|--dry-run] KEY VALUE PATH
 ```
 
 Add operation adds or overwrites a single key at path.

--- a/test/suites/commands/add.bats
+++ b/test/suites/commands/add.bats
@@ -6,12 +6,12 @@ load ../../bin/plugins/bats-assert/load
 @test "vault-${VAULT_VERSION} ${KV_BACKEND} 'add'" {
   #######################################
   echo "==== case: add value to non existing path ===="
-  run ${APP_BIN} -c "add test value ${KV_BACKEND}/fake/path"
+  run ${APP_BIN} -c "add --confirm test value ${KV_BACKEND}/fake/path"
   assert_failure
 
   #######################################
   echo "==== case: add key to existing path ===="
-  run ${APP_BIN} -c "add test value ${KV_BACKEND}/src/a/foo"
+  run ${APP_BIN} -c "add --confirm test value ${KV_BACKEND}/src/a/foo"
   assert_success
 
   echo "ensure the key was written to destination"
@@ -21,17 +21,28 @@ load ../../bin/plugins/bats-assert/load
 
   #######################################
   echo "==== case: add existing key to existing path ===="
-  run ${APP_BIN} -c "add value another ${KV_BACKEND}/src/a/foo"
+  run ${APP_BIN} -c "add --confirm value another ${KV_BACKEND}/src/a/foo"
   assert_failure
   assert_output --partial "Key already exists at path: ${KV_BACKEND}/src/a/foo"
 
   #######################################
   echo "==== case: overwrite existing key to existing path ===="
-  run ${APP_BIN} -c "add -f value another ${KV_BACKEND}/src/a/foo"
+  run ${APP_BIN} -c "add --confirm -f value another ${KV_BACKEND}/src/a/foo"
   assert_success
 
   echo "ensure the key was written to destination"
   run get_vault_value "value" "${KV_BACKEND}/src/a/foo"
   assert_success
   assert_output "another"
+
+  #######################################
+  echo "==== case: add dryrun, ensure key not added ===="
+  run ${APP_BIN} -c "add --dry-run -f proposedvalue willnotexist ${KV_BACKEND}/src/a/foo"
+  assert_success
+  assert_line "Skipping write."
+
+  echo "ensure the key was NOT written to destination"
+  run get_vault_value "proposedvalue" "${KV_BACKEND}/src/a/foo"
+  assert_output --partial "not present in secret"
+
 }


### PR DESCRIPTION
Adding similar behavior from the 'replace' command for --dry-run and --confirm args.