### PR TITLE
Fix caching behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## master - unreleased
 
+## v0.11.0 (February 27, 2021)
+
+ENHANCEMENTS:
+
+* Adding dry-run/confirm flags to the `add` command ([#91](https://github.com/fishi0x01/vsh/pull/91) - Thank you for implementation [dugshnay](https://github.com/dugshnay))
+
+BUG FIXES:
+
+* Fix stale cache in interactive mode ([#92](https://github.com/fishi0x01/vsh/pull/92))
+
 ## v0.10.0 (February 24, 2021)
 
 ENHANCEMENTS:

--- a/completer/completer.go
+++ b/completer/completer.go
@@ -58,7 +58,8 @@ func (c *Completer) absolutePathSuggestions(arg string) (result []prompt.Suggest
 		options, err = c.client.List(queryPath)
 
 		if err != nil {
-			panic(err)
+			log.UserError("Error during auto-completion: %s", err)
+			return result
 		}
 
 		options = append(options, "../")

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ func (args) Description() string {
 
 func executor(in string) {
 	// Every command can change the vault content
-	// i.e., the cache should be cleared on command execution
-	vaultClient.ClearCache()
+	// i.e., the cache should be cleared after a command got executed
+	defer vaultClient.ClearCache()
 
 	// Split the input separate the command and the arguments.
 	in = strings.TrimSpace(in)


### PR DESCRIPTION
Current caching leads to displaying stale auto-complete results in interactive mode. Cache must be cleared directly after a command is executed.

Also, removing forgotten `panic` section.