### PR TITLE
Support vault tls by cert path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ That means `vsh` supports setting vault tokens via `~/.vault-token`, `VAULT_TOKE
 
 ## TLS
 
-Add tls certificate for server by setting `VAULT_CERT` environment variable to the `pem` certificate path.
+Add tls certificate for server by setting `VAULT_CACERT` environment variable to the `pem` certificate path.
 
 ## Token permission requirements
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Download latest static binaries from [release page](https://github.com/fishi0x01
 In order to get a valid token, `vsh` uses vault's TokenHelper mechanism.
 That means `vsh` supports setting vault tokens via `~/.vault-token`, `VAULT_TOKEN` and external [token-helper](https://www.vaultproject.io/docs/commands/token-helper).
 
+## TLS
+
+Add tls certificate for server by setting `VAULT_CERT` environment variable to the `pem` certificate path.
+
 ## Token permission requirements
 
 `vsh` requires `List` permission on the operated paths.

--- a/client/client.go
+++ b/client/client.go
@@ -22,9 +22,10 @@ type Client struct {
 
 // VaultConfig container to keep parameters for Client configuration
 type VaultConfig struct {
-	Addr      string
-	Token     string
-	StartPath string
+	Addr            string
+	Token           string
+	StartPath       string
+	CertificatePath string
 }
 
 func verifyClientPwd(client *Client) (*Client, error) {
@@ -51,14 +52,22 @@ func verifyClientPwd(client *Client) (*Client, error) {
 
 // NewClient creates a new Client Vault wrapper
 func NewClient(conf *VaultConfig) (*Client, error) {
-	vault, err := api.NewClient(&api.Config{
+	config := &api.Config{
 		Address: conf.Addr,
-	})
+	}
+
+	if len(conf.CertificatePath) > 0 {
+		log.UserDebug("Configuring TLS to be " + conf.CertificatePath)
+		config.ConfigureTLS(&api.TLSConfig{
+			CAPath: conf.CertificatePath,
+		})
+	}
+
+	vault, err := api.NewClient(config)
 
 	if err != nil {
 		return nil, err
 	}
-
 	vault.SetToken(conf.Token)
 
 	permissions, err := vault.Sys().CapabilitiesSelf("sys/mounts")

--- a/main.go
+++ b/main.go
@@ -147,9 +147,10 @@ func main() {
 	}
 
 	conf := &client.VaultConfig{
-		Addr:      os.Getenv("VAULT_ADDR"),
-		Token:     token,
-		StartPath: os.Getenv("VAULT_PATH"),
+		Addr:            os.Getenv("VAULT_ADDR"),
+		Token:           token,
+		StartPath:       os.Getenv("VAULT_PATH"),
+		CertificatePath: os.Getenv("VAULT_CERT"),
 	}
 
 	vaultClient, err = client.NewClient(conf)

--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func main() {
 		Addr:            os.Getenv("VAULT_ADDR"),
 		Token:           token,
 		StartPath:       os.Getenv("VAULT_PATH"),
-		CertificatePath: os.Getenv("VAULT_CERT"),
+		CertificatePath: os.Getenv("VAULT_CACERT"),
 	}
 
 	vaultClient, err = client.NewClient(conf)


### PR DESCRIPTION
Allows adding TLS support by setting the certificate path on your filesystem to the `VAULT_CERT` environment variable.