### PR TITLE
make binary small

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fishi0x01/vsh/client"
 	"github.com/fishi0x01/vsh/completer"
 	"github.com/fishi0x01/vsh/log"
-	"github.com/hashicorp/vault/command/config"
 )
 
 var vaultClient *client.Client
@@ -110,15 +109,11 @@ func getCommand(args []string, commands *cli.Commands) (cmd cli.Command, err err
 func getVaultToken() (token string, err error) {
 	token = os.Getenv("VAULT_TOKEN")
 	if token == "" {
-		helper, ve := config.DefaultTokenHelper()
-		if ve != nil {
-			err = ve
-			return token, err
+		tok, err := getTokenFromHelper()
+		if err != nil {
+			return "", err
 		}
-		token, ve = helper.Get()
-		if ve != nil {
-			err = ve
-		}
+		token = tok
 	}
 	return token, err
 }

--- a/tokenhelper.go
+++ b/tokenhelper.go
@@ -1,0 +1,16 @@
+//go:build !notokenhelper
+// +build !notokenhelper
+
+package main
+
+import (
+	"github.com/hashicorp/vault/command/config"
+)
+
+func getTokenFromHelper() (string, error) {
+	helper, err := config.DefaultTokenHelper()
+	if err != nil {
+		return "", err
+	}
+	return helper.Get()
+}

--- a/tokenhelper_off.go
+++ b/tokenhelper_off.go
@@ -1,0 +1,8 @@
+//go:build notokenhelper
+// +build notokenhelper
+
+package main
+
+func getTokenFromHelper() (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
I like this project.

It seems that the binary is quite large, so I make some tests to see if we can reduce its size.

Here are the results:

```
  31M vsh                    go build -o vsh
  23M vsh_min                go build -trimpath -ldflags "-s -w" -o vsh_min
 9.7M vsh_notokenhelper      go build -tags 'notokenhelper' -o vsh_notokenhelper
 6.8M vsh_notokenhelper_min  go build -tags 'notokenhelper' -trimpath -ldflags "-s -w" -o vsh_notokenhelper_min
```

For users who do not require or use the vault token helper, they can install vsh as follows:

`go install -tags 'notokenhelper' github.com/fishi0x01/vsh@latest`
