### PR TITLE
fix: ls with invalid path incorrectly lists all backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 * fix `add` using unresolved relative path when `cwd` is set via `VAULT_PATH` ([#131](https://github.com/fishi0x01/vsh/pull/131))
 * fix variable shadowing in `SetData` causing KV2 branch to be dead code ([#132](https://github.com/fishi0x01/vsh/pull/132))
 * fix concurrency and error handling issues: cache race condition, swallowed errors in recursive operations, logger data race, and resource leak in debug logging ([#133](https://github.com/fishi0x01/vsh/pull/133))
+* fix `ls <arg>` from root incorrectly listing all backends when argument is not a valid path ([#136](https://github.com/fishi0x01/vsh/pull/136))
 
 DEPENDENCIES:
 

--- a/client/util.go
+++ b/client/util.go
@@ -74,7 +74,7 @@ func (client *Client) getKVDataPath(path string) string {
 }
 
 func (client *Client) isTopLevelPath(absolutePath string) bool {
-	return strings.Count(absolutePath, "/") < 2
+	return absolutePath == "/"
 }
 
 func isValidKV2Data(secret *api.Secret) bool {


### PR DESCRIPTION
## Summary

- `isTopLevelPath` used `strings.Count(absolutePath, "/") < 2`, which matched both `/` (root) and any single-component path like `/c`
- `ls c` from root would build path `/c`, hit `isTopLevelPath`, and silently call `listTopLevel()` — returning all backends instead of an error
- Fixed by changing the check to `absolutePath == "/"` so only the exact root triggers top-level listing

## Test plan

- [ ] `ls` from `/` still lists all backends
- [ ] `ls secret/` still lists contents of the secret backend
- [ ] `ls c` from `/` now returns an error for non-existent path

🤖 Generated with [Claude Code](https://claude.com/claude-code)