### PR TITLE
fix: support root/backend paths in SubpathsForPath and fix autocomplete errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ local-vault-standard-test-instance: ## Start a local vault container with standa
 local-vault-concurrency-test-instance: ## Start a local vault container with concurrency setup provisioning
 	bash -c ". test/util/common.bash && . test/util/concurrency-setup.bash && setup"
 
+manual-test: compile ## Start vault with large nested dir tree and open vsh shell for manual testing
+	bash -c ". test/util/common.bash && . test/util/concurrency-setup.bash && setup"
+	VAULT_ADDR=http://localhost:8888 VAULT_TOKEN=root ./build/vsh_$(shell uname | tr '[:upper:]' '[:lower:]')_$(ARCH)
+
 .PHONY: demo
 demo: compile ## Generate demo/demo.gif from demo/demo.tape (requires vhs)
 	bash demo/setup.sh

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -228,6 +228,15 @@ func (client *Client) SubpathsForPath(path string, shallow bool) (filePaths []st
 			}
 			filePaths = append(filePaths, traversedPath)
 		}
+	case BACKEND:
+		// topLevelTraverse returns paths without leading '/', e.g. "KV1/"
+		for _, backendPath := range client.Traverse(path, shallow) {
+			subPaths, subErr := client.SubpathsForPath("/"+backendPath, shallow)
+			if subErr != nil {
+				continue
+			}
+			filePaths = append(filePaths, subPaths...)
+		}
 	default:
 		return filePaths, fmt.Errorf("not a valid path for operation: %s", path)
 	}

--- a/internal/client/type.go
+++ b/internal/client/type.go
@@ -58,6 +58,12 @@ func (client *Client) getDirFiles(path string) (result map[string]int) {
 }
 
 func (client *Client) lowLevelType(path string) (result PathKind) {
+	// A path that is itself a known backend root (e.g. "kv1/") is always a
+	// traversable node, regardless of whether it currently holds any secrets.
+	if _, ok := client.KVBackends[strings.TrimSuffix(path, "/")+"/"]; ok {
+		return NODE
+	}
+
 	dirFiles := client.getDirFiles(path)
 	if client.isAmbiguous(path, dirFiles) {
 		if strings.HasSuffix(path, "/") {
@@ -67,7 +73,7 @@ func (client *Client) lowLevelType(path string) (result PathKind) {
 		}
 	} else {
 		hasNode := false
-		kvPath := client.getKVMetaDataPath(path + "/")
+		kvPath := client.getKVMetaDataPath(strings.TrimSuffix(path, "/") + "/")
 		s, err := client.cache.List(kvPath)
 		if err == nil && s != nil {
 			if _, ok := s.Data["keys"]; ok {

--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -58,7 +58,6 @@ func (c *Completer) absolutePathSuggestions(arg string) (result []prompt.Suggest
 		options, err = c.client.List(queryPath)
 
 		if err != nil {
-			logger.UserError("Error during auto-completion: %s", err)
 			return result
 		}
 


### PR DESCRIPTION
## Summary

- `SubpathsForPath` now handles `BACKEND` type (e.g. `/`) by recursing into each backend, so commands like `grep` work from the root path
- `lowLevelType` returns `NODE` for known backend roots by checking `KVBackends` directly, fixing false `not a valid path` errors on empty backends and `Not a directory` errors during autocomplete
- Fixed double-slash bug in `lowLevelType` `hasNode` check (`TrimSuffix` before appending `/`)
- Autocomplete no longer logs errors on invalid/incomplete paths (silently returns no suggestions instead)
- Added `manual-test` Makefile target to spin up a concurrency Vault instance and open an interactive vsh shell

## Test plan

- [ ] `grep <pattern>` from `/` traverses all backends without error
- [ ] `grep <pattern> /kv1/` works on an empty backend without error
- [ ] Tab-completing an absolute path like `/kv1/` shows no error messages in the terminal
- [ ] `make manual-test` starts vault with nested dir tree and opens vsh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)