### PR TITLE
feat: prompt confirmation for recursive rm, add -f flag

### DIFF
--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -49,7 +49,7 @@ func (cmds *Commands) Get(cmd string) Command {
 }
 
 // NewCommands returns a Commands struct with all available commands
-func NewCommands(client *client.Client, workerCount int) *Commands {
+func NewCommands(client *client.Client, workerCount int, interactive bool) *Commands {
 	return &Commands{
 		Add:     NewAddCommand(client),
 		Append:  NewAppendCommand(client),
@@ -60,7 +60,7 @@ func NewCommands(client *client.Client, workerCount int) *Commands {
 		Ls:      NewListCommand(client),
 		Mv:      NewMoveCommand(client, workerCount),
 		Replace: NewReplaceCommand(client),
-		Rm:      NewRemoveCommand(client, workerCount),
+		Rm:      NewRemoveCommand(client, workerCount, interactive),
 	}
 }
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/fishi0x01/vsh/internal/client"
@@ -13,6 +16,7 @@ type RemoveCommand struct {
 	name        string
 	args        *RemoveCommandArgs
 	workerCount int
+	interactive bool
 
 	client *client.Client
 }
@@ -20,6 +24,7 @@ type RemoveCommand struct {
 // RemoveCommandArgs provides a struct for go-arg parsing
 type RemoveCommandArgs struct {
 	Recursive bool   `arg:"-r"                  help:"recursively remove a directory"`
+	Force     bool   `arg:"-f"                  help:"skip confirmation prompt for recursive removal"`
 	Path      string `arg:"positional,required" help:"path to remove"`
 }
 
@@ -29,12 +34,13 @@ func (RemoveCommandArgs) Description() string {
 }
 
 // NewRemoveCommand creates a new RemoveCommand parameter container
-func NewRemoveCommand(c *client.Client, workerCount int) *RemoveCommand {
+func NewRemoveCommand(c *client.Client, workerCount int, interactive bool) *RemoveCommand {
 	return &RemoveCommand{
 		name:        "rm",
 		client:      c,
 		args:        &RemoveCommandArgs{},
 		workerCount: workerCount,
+		interactive: interactive,
 	}
 }
 
@@ -83,6 +89,15 @@ func (cmd *RemoveCommand) Run() int {
 		if !cmd.args.Recursive {
 			logger.UserError("use -r to remove directories")
 			return 1
+		}
+		if cmd.interactive && !cmd.args.Force {
+			fmt.Printf("Remove entire subtree at '%s'? [y/N] ", newPwd)
+			reader := bufio.NewReader(os.Stdin)
+			answer, _ := reader.ReadString('\n')
+			if strings.ToLower(strings.TrimSpace(answer)) != "y" {
+				fmt.Println("Aborted.")
+				return 0
+			}
 		}
 		var wg sync.WaitGroup
 		sem := make(chan struct{}, cmd.workerCount)

--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -125,7 +125,7 @@ func (c *Completer) isCommandArgument(p string) bool {
 		return false
 	}
 
-	commands := cli.NewCommands(c.client, 1)
+	commands := cli.NewCommands(c.client, 1, false)
 	for _, f := range structs.Fields(commands) {
 		if words[0] == f.Value().(cli.Command).GetName() || words[0] == "toggle-auto-completion" {
 			return true
@@ -140,7 +140,7 @@ func isCommand(p string) bool {
 
 func (c *Completer) commandSuggestions(arg string) []Suggestion {
 	result := make([]Suggestion, 0)
-	commands := cli.NewCommands(c.client, 1)
+	commands := cli.NewCommands(c.client, 1, false)
 	for _, f := range structs.Fields(commands) {
 		val := f.Value().(cli.Command)
 		result = append(result, Suggestion{Text: val.GetName(), Description: cli.Usage(val)})

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func (a *app) executor(in string) {
 		logger.UserError("%v", err)
 		return
 	}
-	commands := cli.NewCommands(a.vaultClient, a.workerCount)
+	commands := cli.NewCommands(a.vaultClient, a.workerCount, a.isInteractive)
 	var cmd cli.Command
 
 	// parse command


### PR DESCRIPTION
## Summary

- `rm -r <path>` in interactive mode now asks `Remove entire subtree at '<path>'? [y/N]` before proceeding
- New `-f` flag skips the confirmation prompt (useful for scripted interactive sessions)
- Non-interactive mode (`vsh -c "rm -r ..."`) always skips the prompt — no behavior change there

## Test plan

- [ ] Run `rm -r <dir>/` interactively, verify prompt appears and `n`/enter aborts without deleting
- [ ] Run `rm -r -f <dir>/` interactively, verify it deletes without prompting
- [ ] Run `vsh -c "rm -r <dir>/"` non-interactively, verify it deletes without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)