### PR TITLE
feat: concurrent grep/replace, pause spinner for mid-run prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 * require `-r` flag for recursive `cp` and `rm` operations on directories ([#128](https://github.com/fishi0x01/vsh/pull/128))
 * replace unmaintained `c-bata/go-prompt` with `charmbracelet/bubbletea` for a richer interactive TUI: styled completion dropdown with selection marker, stable prompt prefix colour, history navigation, and a braille spinner during long-running operations ([#139](https://github.com/fishi0x01/vsh/pull/139))
 * prompt confirmation before recursive `rm -r` in interactive mode; use `-f` to skip the prompt ([#140](https://github.com/fishi0x01/vsh/pull/140))
+* concurrent reads for `grep` and `replace` (find phase) and concurrent writes for `replace`, tunable with `--worker-count` flag (default: 10) ([#141](https://github.com/fishi0x01/vsh/pull/141))
 
 BUG FIXES:
 
@@ -16,7 +17,7 @@ BUG FIXES:
 * fix variable shadowing in `SetData` causing KV2 branch to be dead code ([#132](https://github.com/fishi0x01/vsh/pull/132))
 * fix concurrency and error handling issues: cache race condition, swallowed errors in recursive operations, logger data race, and resource leak in debug logging ([#133](https://github.com/fishi0x01/vsh/pull/133))
 * fix `ls <arg>` from root incorrectly listing all backends when argument is not a valid path ([#136](https://github.com/fishi0x01/vsh/pull/136))
-* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries ([#141](https://github.com/fishi0x01/vsh/pull/141))
+* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#141](https://github.com/fishi0x01/vsh/pull/141))
 
 DEPENDENCIES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ ENHANCEMENTS:
 * require `-r` flag for recursive `cp` and `rm` operations on directories ([#128](https://github.com/fishi0x01/vsh/pull/128))
 * replace unmaintained `c-bata/go-prompt` with `charmbracelet/bubbletea` for a richer interactive TUI: styled completion dropdown with selection marker, stable prompt prefix colour, history navigation, and a braille spinner during long-running operations ([#139](https://github.com/fishi0x01/vsh/pull/139))
 * prompt confirmation before recursive `rm -r` in interactive mode; use `-f` to skip the prompt ([#140](https://github.com/fishi0x01/vsh/pull/140))
-* concurrent reads for `grep` and `replace` (find phase) and concurrent writes for `replace`, tunable with `--worker-count` flag (default: 10) ([#141](https://github.com/fishi0x01/vsh/pull/141))
+* concurrent reads for `grep` and `replace` (find phase) and concurrent writes for `replace`, tunable with `--worker-count` flag (default: 10) ([#142](https://github.com/fishi0x01/vsh/pull/142))
 
 BUG FIXES:
 
@@ -17,7 +17,7 @@ BUG FIXES:
 * fix variable shadowing in `SetData` causing KV2 branch to be dead code ([#132](https://github.com/fishi0x01/vsh/pull/132))
 * fix concurrency and error handling issues: cache race condition, swallowed errors in recursive operations, logger data race, and resource leak in debug logging ([#133](https://github.com/fishi0x01/vsh/pull/133))
 * fix `ls <arg>` from root incorrectly listing all backends when argument is not a valid path ([#136](https://github.com/fishi0x01/vsh/pull/136))
-* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#141](https://github.com/fishi0x01/vsh/pull/141))
+* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#142](https://github.com/fishi0x01/vsh/pull/142))
 
 DEPENDENCIES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ BUG FIXES:
 * fix variable shadowing in `SetData` causing KV2 branch to be dead code ([#132](https://github.com/fishi0x01/vsh/pull/132))
 * fix concurrency and error handling issues: cache race condition, swallowed errors in recursive operations, logger data race, and resource leak in debug logging ([#133](https://github.com/fishi0x01/vsh/pull/133))
 * fix `ls <arg>` from root incorrectly listing all backends when argument is not a valid path ([#136](https://github.com/fishi0x01/vsh/pull/136))
-* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#141](https://github.com/fishi0x01/vsh/pull/141))
+* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries ([#141](https://github.com/fishi0x01/vsh/pull/141))
+* fix `add` and `replace` confirmation prompts garbled by spinner ([#142](https://github.com/fishi0x01/vsh/pull/142))
 
 DEPENDENCIES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ BUG FIXES:
 * fix variable shadowing in `SetData` causing KV2 branch to be dead code ([#132](https://github.com/fishi0x01/vsh/pull/132))
 * fix concurrency and error handling issues: cache race condition, swallowed errors in recursive operations, logger data race, and resource leak in debug logging ([#133](https://github.com/fishi0x01/vsh/pull/133))
 * fix `ls <arg>` from root incorrectly listing all backends when argument is not a valid path ([#136](https://github.com/fishi0x01/vsh/pull/136))
-* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#142](https://github.com/fishi0x01/vsh/pull/142))
+* fix `rm -r` confirmation prompt garbled by spinner; fix spurious blank lines between completion dropdown entries; fix `add` and `replace` confirmation prompts garbled by spinner ([#141](https://github.com/fishi0x01/vsh/pull/141))
 
 DEPENDENCIES:
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -12,7 +12,16 @@ type AddCommand struct {
 	name string
 	args *AddCommandArgs
 
-	client *client.Client
+	client        *client.Client
+	pauseSpinner  func()
+	resumeSpinner func()
+}
+
+// SetSpinnerControl satisfies SpinnerAware so the spinner can be paused
+// while askForConfirmation is reading stdin.
+func (cmd *AddCommand) SetSpinnerControl(pause, resume func()) {
+	cmd.pauseSpinner = pause
+	cmd.resumeSpinner = resume
 }
 
 // AddCommandArgs provides a struct for go-arg parsing
@@ -103,7 +112,13 @@ func (cmd *AddCommand) addKeyValue(path string, key string, value string) error 
 	data[key] = value
 	secret.SetData(data)
 	if !cmd.args.Confirm && !cmd.args.DryRun {
+		if cmd.pauseSpinner != nil {
+			cmd.pauseSpinner()
+		}
 		result, err := askForConfirmation("Write changes to Vault?")
+		if cmd.resumeSpinner != nil {
+			cmd.resumeSpinner()
+		}
 		if err != nil {
 			return fmt.Errorf("error prompting for confirmation: %v", err)
 		}

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -26,6 +26,12 @@ type Confirmer interface {
 	Confirm() bool
 }
 
+// SpinnerAware is implemented by commands that call interactive prompts
+// mid-execution and need to pause the spinner to avoid corrupted output.
+type SpinnerAware interface {
+	SetSpinnerControl(pause, resume func())
+}
+
 // Commands contains all available commands
 type Commands struct {
 	Add     *AddCommand
@@ -62,10 +68,10 @@ func NewCommands(client *client.Client, workerCount int, interactive bool) *Comm
 		Cat:     NewCatCommand(client),
 		Cd:      NewCdCommand(client),
 		Cp:      NewCopyCommand(client, workerCount),
-		Grep:    NewGrepCommand(client),
+		Grep:    NewGrepCommand(client, workerCount),
 		Ls:      NewListCommand(client),
 		Mv:      NewMoveCommand(client, workerCount),
-		Replace: NewReplaceCommand(client),
+		Replace: NewReplaceCommand(client, workerCount),
 		Rm:      NewRemoveCommand(client, workerCount, interactive),
 	}
 }

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/fishi0x01/vsh/internal/client"
 	"github.com/fishi0x01/vsh/internal/logger"
@@ -10,8 +11,9 @@ import (
 
 // GrepCommand container for all 'grep' parameters
 type GrepCommand struct {
-	name string
-	args *GrepCommandArgs
+	name        string
+	args        *GrepCommandArgs
+	workerCount int
 
 	client   *client.Client
 	searcher *Searcher
@@ -34,11 +36,12 @@ func (GrepCommandArgs) Description() string {
 }
 
 // NewGrepCommand creates a new GrepCommand parameter container
-func NewGrepCommand(c *client.Client) *GrepCommand {
+func NewGrepCommand(c *client.Client, workerCount int) *GrepCommand {
 	return &GrepCommand{
-		name:   "grep",
-		client: c,
-		args:   &GrepCommandArgs{},
+		name:        "grep",
+		client:      c,
+		args:        &GrepCommandArgs{},
+		workerCount: workerCount,
 	}
 }
 
@@ -99,12 +102,31 @@ func (cmd *GrepCommand) Run() int {
 		return 1
 	}
 
-	for _, curPath := range filePaths {
-		matches, err := cmd.grepFile(cmd.args.Search, curPath)
-		if err != nil {
+	type result struct {
+		matches []*Match
+		err     error
+	}
+	results := make([]result, len(filePaths))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, cmd.workerCount)
+	for i, curPath := range filePaths {
+		wg.Add(1)
+		go func(idx int, p string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			matches, err := cmd.grepFile(cmd.args.Search, p)
+			results[idx] = result{matches, err}
+		}(i, curPath)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.err != nil {
 			return 1
 		}
-		for _, match := range matches {
+		for _, match := range r.matches {
 			match.print(os.Stdout, MatchOutputHighlight)
 		}
 	}

--- a/internal/cli/replace.go
+++ b/internal/cli/replace.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/fishi0x01/vsh/internal/client"
 	"github.com/fishi0x01/vsh/internal/logger"
@@ -10,12 +11,22 @@ import (
 
 // ReplaceCommand container for all 'replace' parameters
 type ReplaceCommand struct {
-	name string
-	args *ReplaceCommandArgs
+	name        string
+	args        *ReplaceCommandArgs
+	workerCount int
 
-	client   *client.Client
-	searcher *Searcher
-	Mode     KeyValueMode
+	client        *client.Client
+	searcher      *Searcher
+	Mode          KeyValueMode
+	pauseSpinner  func()
+	resumeSpinner func()
+}
+
+// SetSpinnerControl satisfies SpinnerAware so the spinner can be paused
+// while askForConfirmation is reading stdin.
+func (cmd *ReplaceCommand) SetSpinnerControl(pause, resume func()) {
+	cmd.pauseSpinner = pause
+	cmd.resumeSpinner = resume
 }
 
 // ReplaceCommandArgs provides a struct for go-arg parsing
@@ -39,11 +50,12 @@ func (ReplaceCommandArgs) Description() string {
 }
 
 // NewReplaceCommand creates a new ReplaceCommand parameter container
-func NewReplaceCommand(c *client.Client) *ReplaceCommand {
+func NewReplaceCommand(c *client.Client, workerCount int) *ReplaceCommand {
 	return &ReplaceCommand{
-		name:   "replace",
-		client: c,
-		args:   &ReplaceCommandArgs{},
+		name:        "replace",
+		client:      c,
+		args:        &ReplaceCommandArgs{},
+		workerCount: workerCount,
 	}
 }
 
@@ -130,21 +142,37 @@ func (cmd *ReplaceCommand) Run() int {
 func (cmd *ReplaceCommand) findMatches(
 	filePaths []string,
 ) (matchesByPath map[string][]*Match, err error) {
-	matchesByPath = make(map[string][]*Match, 0)
-	for _, curPath := range filePaths {
-		matches, err := cmd.FindReplacements(cmd.args.Search, cmd.args.Replacement, curPath)
-		if err != nil {
-			return matchesByPath, err
+	type result struct {
+		path    string
+		matches []*Match
+		err     error
+	}
+	results := make([]result, len(filePaths))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, cmd.workerCount)
+	for i, curPath := range filePaths {
+		wg.Add(1)
+		go func(idx int, p string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			matches, err := cmd.FindReplacements(cmd.args.Search, cmd.args.Replacement, p)
+			results[idx] = result{p, matches, err}
+		}(i, curPath)
+	}
+	wg.Wait()
+
+	matchesByPath = make(map[string][]*Match)
+	for _, r := range results {
+		if r.err != nil {
+			return matchesByPath, r.err
 		}
-		for _, match := range matches {
+		for _, match := range r.matches {
 			match.print(os.Stdout, cmd.args.Output.Value)
 		}
-		if len(matches) > 0 {
-			_, ok := matchesByPath[curPath]
-			if !ok {
-				matchesByPath[curPath] = make([]*Match, 0)
-			}
-			matchesByPath[curPath] = append(matchesByPath[curPath], matches...)
+		if len(r.matches) > 0 {
+			matchesByPath[r.path] = append(matchesByPath[r.path], r.matches...)
 		}
 	}
 	return matchesByPath, nil
@@ -153,7 +181,13 @@ func (cmd *ReplaceCommand) findMatches(
 func (cmd *ReplaceCommand) commitMatches(matchesByPath map[string][]*Match) int {
 	if len(matchesByPath) > 0 {
 		if !cmd.args.Confirm && !cmd.args.DryRun {
+			if cmd.pauseSpinner != nil {
+				cmd.pauseSpinner()
+			}
 			result, err := askForConfirmation("Write changes to Vault?")
+			if cmd.resumeSpinner != nil {
+				cmd.resumeSpinner()
+			}
 			if err != nil {
 				return 1
 			}
@@ -194,32 +228,56 @@ func (cmd *ReplaceCommand) FindReplacements(
 	return matches, nil
 }
 
-// WriteReplacements will write replacement data back to Vault
+// WriteReplacements will write replacement data back to Vault concurrently
 func (cmd *ReplaceCommand) WriteReplacements(groupedMatches map[string][]*Match) error {
-	// process matches by vault path
+	failed := make(chan error, 1)
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, cmd.workerCount)
+
 	for path, matches := range groupedMatches {
-		secret, err := cmd.client.Read(path)
-		if err != nil {
-			return err
-		}
-		data := secret.GetData()
+		wg.Add(1)
+		go func(p string, m []*Match) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 
-		// update secret with changes. remove key w/ prior names, add renamed keys, update values.
-		for _, match := range matches {
-			if path != match.path {
-				return fmt.Errorf("match path does not equal group path")
+			secret, err := cmd.client.Read(p)
+			if err != nil {
+				select {
+				case failed <- err:
+				default:
+				}
+				return
 			}
-			if match.replacedKey != match.key {
-				delete(data, match.key)
+			data := secret.GetData()
+			for _, match := range m {
+				if p != match.path {
+					select {
+					case failed <- fmt.Errorf("match path does not equal group path"):
+					default:
+					}
+					return
+				}
+				if match.replacedKey != match.key {
+					delete(data, match.key)
+				}
+				data[match.replacedKey] = match.replacedValue
 			}
-			data[match.replacedKey] = match.replacedValue
-		}
-		secret.SetData(data)
-
-		err = cmd.client.Write(path, secret)
-		if err != nil {
-			return err
-		}
+			secret.SetData(data)
+			if err := cmd.client.Write(p, secret); err != nil {
+				select {
+				case failed <- err:
+				default:
+				}
+			}
+		}(path, matches)
 	}
-	return nil
+	wg.Wait()
+
+	select {
+	case err := <-failed:
+		return err
+	default:
+		return nil
+	}
 }

--- a/internal/tui/spinner.go
+++ b/internal/tui/spinner.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -13,6 +14,43 @@ const graceDelay = 120 * time.Millisecond
 
 // tickInterval controls spinner animation speed.
 const tickInterval = 80 * time.Millisecond
+
+// spinnerHandle lets the goroutine running inside RunWithSpinner pause and
+// resume the spinner loop for interactive prompts.
+type spinnerHandle struct {
+	pauseReq  chan struct{}
+	pauseAck  chan struct{} // spinner sends after it has cleared the line
+	resumeReq chan struct{}
+}
+
+var (
+	activeHandleMu sync.Mutex
+	activeHandle   *spinnerHandle
+)
+
+// PauseSpinner pauses the running spinner (if any) and blocks until the
+// spinner line has been cleared. Safe to call when no spinner is active.
+func PauseSpinner() {
+	activeHandleMu.Lock()
+	h := activeHandle
+	activeHandleMu.Unlock()
+	if h == nil {
+		return
+	}
+	h.pauseReq <- struct{}{}
+	<-h.pauseAck
+}
+
+// ResumeSpinner resumes the spinner after PauseSpinner.
+func ResumeSpinner() {
+	activeHandleMu.Lock()
+	h := activeHandle
+	activeHandleMu.Unlock()
+	if h == nil {
+		return
+	}
+	h.resumeReq <- struct{}{}
+}
 
 // RunWithSpinner runs f in a goroutine and shows a spinner on stdout while it
 // runs. The spinner only appears if f takes longer than graceDelay, so fast
@@ -31,7 +69,21 @@ func RunWithSpinner(f func()) {
 	case <-time.After(graceDelay):
 	}
 
-	// f is still running — start animating.
+	// f is still running — register the handle so PauseSpinner can find it.
+	h := &spinnerHandle{
+		pauseReq:  make(chan struct{}),
+		pauseAck:  make(chan struct{}),
+		resumeReq: make(chan struct{}),
+	}
+	activeHandleMu.Lock()
+	activeHandle = h
+	activeHandleMu.Unlock()
+	defer func() {
+		activeHandleMu.Lock()
+		activeHandle = nil
+		activeHandleMu.Unlock()
+	}()
+
 	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 
@@ -43,6 +95,15 @@ func RunWithSpinner(f func()) {
 		case <-done:
 			fmt.Print("\r\033[K") // clear the spinner line
 			return
+		case <-h.pauseReq:
+			fmt.Print("\r\033[K") // clear before handing control back
+			h.pauseAck <- struct{}{}
+			select {
+			case <-h.resumeReq:
+			case <-done:
+				fmt.Print("\r\033[K")
+				return
+			}
 		case <-ticker.C:
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -96,6 +96,11 @@ func (a *app) executor(in string) {
 	}
 
 	if err == nil && cmd.IsSane() {
+		if a.isInteractive {
+			if sa, ok := cmd.(cli.SpinnerAware); ok {
+				sa.SetSpinnerControl(tui.PauseSpinner, tui.ResumeSpinner)
+			}
+		}
 		ret := cmd.Run()
 		if !a.isInteractive {
 			os.Exit(ret)


### PR DESCRIPTION
## Summary

- **Concurrent `grep` and `replace`**: both commands previously iterated all Vault paths sequentially. Reads in `grep` and the find phase of `replace` now fan out across a goroutine pool (tunable via `--worker-count`, default 10). `replace` writes are also concurrent. Results are collected into a position-indexed slice and printed in the original path order so output remains deterministic.
- **Spinner pause/resume for `add` and `replace` prompts**: `add` and `replace` call `askForConfirmation` mid-execution (after reads, before writes). The spinner goroutine was racing with the prompt on stdout. A `PauseSpinner`/`ResumeSpinner` mechanism using a channel handshake ensures the spinner clears its own line and acknowledges before the prompt is printed. A `SpinnerAware` interface lets commands opt in; `executor` wires up the callbacks in interactive mode.

## Test plan

- [ ] `grep <pattern> <large-path>` completes faster and results are in consistent path order
- [ ] `replace <search> <replacement> <large-path>` find phase is faster; write phase is concurrent; results are in consistent path order
- [ ] `add <key> <value> <path>` confirmation prompt shows cleanly with no spinner artefacts
- [ ] `replace <search> <replacement> <path>` confirmation prompt shows cleanly with no spinner artefacts
- [ ] `--worker-count` flag controls concurrency for `grep` and `replace`
- [ ] `replace -y` and `replace -n` bypass the prompt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)